### PR TITLE
Bundle Access Private By Default

### DIFF
--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -77,7 +77,7 @@ func init() {
 	bundleCmd.AddCommand(bundleBuildCmd)
 	bundleBuildCmd.Flags().StringP("build-directory", "b", ".", "Path to a directory containing a massdriver.yaml file.")
 	bundleCmd.AddCommand(bundlePublishCmd)
-	bundlePublishCmd.Flags().String("access", "", "Override the access, useful in CI for deploying to sandboxes.")
+	bundlePublishCmd.Flags().String("access", "private", "Override the access, useful in CI for deploying to sandboxes.")
 	bundlePublishCmd.Flags().StringP("build-directory", "b", ".", "Path to a directory containing a massdriver.yaml file.")
 }
 
@@ -146,7 +146,7 @@ func runBundleBuild(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	unmarshalledBundle, err := unmarshalBundle(buildDirectory, fs)
+	unmarshalledBundle, err := unmarshalBundle(buildDirectory, cmd, fs)
 
 	if err != nil {
 		return err
@@ -170,7 +170,7 @@ func runBundlePublish(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	unmarshalledBundle, err := unmarshalBundle(buildDirectory, fs)
+	unmarshalledBundle, err := unmarshalBundle(buildDirectory, cmd, fs)
 
 	if err != nil {
 		return err
@@ -188,7 +188,7 @@ func runBundlePublish(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func unmarshalBundle(readDirectory string, fs afero.Fs) (*bundle.Bundle, error) {
+func unmarshalBundle(readDirectory string, cmd *cobra.Command, fs afero.Fs) (*bundle.Bundle, error) {
 	file, err := afero.ReadFile(fs, path.Join(readDirectory, "massdriver.yaml"))
 
 	if err != nil {

--- a/internal/bundle/prompt.go
+++ b/internal/bundle/prompt.go
@@ -66,7 +66,6 @@ var MassdriverArtifactDefinitions = []string{
 var promptsNew = []func(t *templatecache.TemplateData) error{
 	getName,
 	getDescription,
-	getAccessLevel,
 	getTemplate,
 	GetConnections,
 	getOutputDir,
@@ -107,26 +106,6 @@ func getName(t *templatecache.TemplateData) error {
 	}
 
 	t.Name = result
-	return nil
-}
-
-func getAccessLevel(t *templatecache.TemplateData) error {
-	if t.Access != "" {
-		return nil
-	}
-
-	prompt := promptui.Select{
-		Label: "Access Level",
-		Items: []string{"public", "private"},
-	}
-
-	_, result, err := prompt.Run()
-
-	if err != nil {
-		return err
-	}
-
-	t.Access = result
 	return nil
 }
 


### PR DESCRIPTION
To prevent accidently public publishing and to remove the friction of users having to pick, bundle access will be set as private by default and will require and override flag to set to public.