### PR TITLE
Feature/adding build directory argument

### DIFF
--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -183,7 +183,7 @@ func runBundlePublish(cmd *cobra.Command, args []string) error {
 
 	c := restclient.NewClient().WithAPIKey(config.APIKey)
 
-	err = commands.BuildBundle(".", unmarshalledBundle, c, fs)
+	err = commands.BuildBundle(buildDirectory, unmarshalledBundle, c, fs)
 
 	if err != nil {
 		return err

--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -75,7 +75,6 @@ func init() {
 	bundleTemplateCmd.AddCommand(bundleTemplateListCmd)
 	bundleTemplateCmd.AddCommand(bundleTemplateRefreshCmd)
 	bundleCmd.AddCommand(bundleBuildCmd)
-	bundleBuildCmd.Flags().StringP("output", "o", ".", "Path to output directory (default is massdriver.yaml directory)")
 	bundleBuildCmd.Flags().StringP("build-directory", "b", ".", "Path to a directory containing a massdriver.yaml file.")
 	bundleCmd.AddCommand(bundlePublishCmd)
 	bundlePublishCmd.Flags().StringP("build-directory", "b", ".", "Path to a directory containing a massdriver.yaml file.")
@@ -139,12 +138,6 @@ func runBundleNew(cmd *cobra.Command, args []string) error {
 
 func runBundleBuild(cmd *cobra.Command, args []string) error {
 	var fs = afero.NewOsFs()
-
-	_, err := cmd.Flags().GetString("output")
-
-	if err != nil {
-		return err
-	}
 
 	buildDirectory, err := cmd.Flags().GetString("build-directory")
 

--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -75,8 +75,10 @@ func init() {
 	bundleTemplateCmd.AddCommand(bundleTemplateListCmd)
 	bundleTemplateCmd.AddCommand(bundleTemplateRefreshCmd)
 	bundleCmd.AddCommand(bundleBuildCmd)
-	bundleBuildCmd.Flags().StringP("output", "o", "", "Path to output directory (default is massdriver.yaml directory)")
+	bundleBuildCmd.Flags().StringP("output", "o", ".", "Path to output directory (default is massdriver.yaml directory)")
+	bundleBuildCmd.Flags().StringP("build-directory", "b", ".", "Path to a directory containing a massdriver.yaml file.")
 	bundleCmd.AddCommand(bundlePublishCmd)
+	bundlePublishCmd.Flags().StringP("build-directory", "b", ".", "Path to a directory containing a massdriver.yaml file.")
 }
 
 func runBundleTemplateList(cmd *cobra.Command, args []string) error {
@@ -138,17 +140,19 @@ func runBundleNew(cmd *cobra.Command, args []string) error {
 func runBundleBuild(cmd *cobra.Command, args []string) error {
 	var fs = afero.NewOsFs()
 
-	outputDir, err := cmd.Flags().GetString("output")
+	_, err := cmd.Flags().GetString("output")
 
 	if err != nil {
 		return err
 	}
 
-	if outputDir == "" {
-		outputDir = "."
+	buildDirectory, err := cmd.Flags().GetString("build-directory")
+
+	if err != nil {
+		return err
 	}
 
-	unmarshalledBundle, err := unmarshalBundle(fs)
+	unmarshalledBundle, err := unmarshalBundle(buildDirectory, fs)
 
 	if err != nil {
 		return err
@@ -156,7 +160,7 @@ func runBundleBuild(cmd *cobra.Command, args []string) error {
 
 	c := restclient.NewClient()
 
-	err = commands.BuildBundle(outputDir, unmarshalledBundle, c, fs)
+	err = commands.BuildBundle(buildDirectory, unmarshalledBundle, c, fs)
 
 	return err
 }
@@ -165,7 +169,13 @@ func runBundlePublish(cmd *cobra.Command, args []string) error {
 	config := config.Get()
 	var fs = afero.NewOsFs()
 
-	unmarshalledBundle, err := unmarshalBundle(fs)
+	buildDirectory, err := cmd.Flags().GetString("build-directory")
+
+	if err != nil {
+		return err
+	}
+
+	unmarshalledBundle, err := unmarshalBundle(buildDirectory, fs)
 
 	if err != nil {
 		return err
@@ -179,12 +189,12 @@ func runBundlePublish(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	publish.Run(unmarshalledBundle, c, fs, ".")
+	publish.Run(unmarshalledBundle, c, fs, buildDirectory)
 	return nil
 }
 
-func unmarshalBundle(fs afero.Fs) (*bundle.Bundle, error) {
-	file, err := afero.ReadFile(fs, path.Join(".", "massdriver.yaml"))
+func unmarshalBundle(readDirectory string, fs afero.Fs) (*bundle.Bundle, error) {
+	file, err := afero.ReadFile(fs, path.Join(readDirectory, "massdriver.yaml"))
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Adding a flag which sets the build directory allowing github actions or MD to build and publish from a sub directory without changing directory.
Also removing the -o flag because having schemas in a different place than the bundle source feels like a bad idea. This allows apps to have a nested bundle or massdriver dir to build from keeping the root directory clean.