### PR TITLE
image push: Always push "latest" tag

### DIFF
--- a/internal/commands/image/push.go
+++ b/internal/commands/image/push.go
@@ -55,6 +55,24 @@ func Push(client graphql.Client, input PushImageInput, imageClient Client) error
 
 	fmt.Println("Pushing image to repository. This may take a few minutes")
 
+	err = pushImage(input, imageClient, containerRepository)
+
+	if err != nil {
+		return err
+	}
+
+	if input.Tag != "latest" {
+		input.Tag = "latest"
+		err = pushImage(input, imageClient, containerRepository)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func pushImage(input PushImageInput, imageClient Client, containerRepository *api.ContainerRepository) error {
 	rd, err := imageClient.PushImage(input, containerRepository)
 
 	if err != nil {
@@ -68,27 +86,9 @@ func Push(client graphql.Client, input PushImageInput, imageClient Client) error
 	}
 
 	var fqn = prettylogs.Underline(imageFqn(containerRepository.RepositoryURI, input.ImageName, input.Tag))
-	msg = fmt.Sprintf("Image %s pushed successfully", fqn)
+	msg := fmt.Sprintf("Image %s pushed successfully", fqn)
 	fmt.Println(msg)
 
-	if input.Tag != "latest" {
-		input.Tag = "latest"
-		rd, err := imageClient.PushImage(input, containerRepository)
-
-		if err != nil {
-			return err
-		}
-
-		err = handleResponseBuffer(rd)
-
-		if err != nil {
-			return err
-		}
-
-		var fqn = prettylogs.Underline(imageFqn(containerRepository.RepositoryURI, input.ImageName, input.Tag))
-		msg = fmt.Sprintf("Image %s also pushed successfully", fqn)
-		fmt.Println(msg)
-	}
 	return nil
 }
 

--- a/internal/commands/image/push.go
+++ b/internal/commands/image/push.go
@@ -71,6 +71,24 @@ func Push(client graphql.Client, input PushImageInput, imageClient Client) error
 	msg = fmt.Sprintf("Image %s pushed successfully", fqn)
 	fmt.Println(msg)
 
+	if input.Tag != "latest" {
+		input.Tag = "latest"
+		rd, err := imageClient.PushImage(input, containerRepository)
+
+		if err != nil {
+			return err
+		}
+
+		err = handleResponseBuffer(rd)
+
+		if err != nil {
+			return err
+		}
+
+		var fqn = prettylogs.Underline(imageFqn(containerRepository.RepositoryURI, input.ImageName, input.Tag))
+		msg = fmt.Sprintf("Image %s also pushed successfully", fqn)
+		fmt.Println(msg)
+	}
 	return nil
 }
 

--- a/internal/commands/image/push_test.go
+++ b/internal/commands/image/push_test.go
@@ -52,7 +52,7 @@ func (mockGQLClient) GetContainerRepository(client graphql.Client, artifactID st
 	}, nil
 }
 
-func TestPushImage(t *testing.T) {
+func TestPushLatestImage(t *testing.T) {
 	var buf bytes.Buffer
 	log.SetOutput(&buf)
 	defer func() {
@@ -69,6 +69,34 @@ func TestPushImage(t *testing.T) {
 		ArtifactID:         "00000-000-000-00000000",
 		OrganizationID:     "00000-000-000-00000000",
 		Tag:                "latest",
+		DockerBuildContext: ".",
+		Dockerfile:         "DockerFile",
+	}
+
+	err := image.Push(mockGQLClient, input, imageClient)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPushImage(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer func() {
+		log.SetOutput((os.Stderr))
+	}()
+
+	mockGQLClient := &mockGQLClient{}
+	imageClient := image.Client{
+		Cli: &mockCli{},
+	}
+	input := image.PushImageInput{
+		ImageName:          "test/docker",
+		Location:           "us-west-2",
+		ArtifactID:         "00000-000-000-00000000",
+		OrganizationID:     "00000-000-000-00000000",
+		Tag:                "some-tag",
 		DockerBuildContext: ".",
 		Dockerfile:         "DockerFile",
 	}


### PR DESCRIPTION
If `mass image push` is invoked with an image tag other than "latest", push "latest" in addition to whichever tag was specified.