### PR TITLE
Move dockerURI regexp to package var

### DIFF
--- a/internal/commands/image/docker_client.go
+++ b/internal/commands/image/docker_client.go
@@ -16,6 +16,8 @@ import (
 	"github.com/massdriver-cloud/mass/internal/api"
 )
 
+var dockerURIPattern = regexp.MustCompile("[a-zA-Z0-9-_]+.docker.pkg.dev")
+
 type DockerClient interface {
 	ImageBuild(ctx context.Context, buildContext io.Reader, options types.ImageBuildOptions) (types.ImageBuildResponse, error)
 	ImagePush(ctx context.Context, image string, options types.ImagePushOptions) (io.ReadCloser, error)
@@ -124,11 +126,9 @@ func setAuthUserNameByCloud(containerRepository *api.ContainerRepository, auth *
 }
 
 func maybeRemoveSuffix(containerRepository *api.ContainerRepository, auth *types.AuthConfig) error {
-	r := regexp.MustCompile("[a-zA-Z0-9-_]+.docker.pkg.dev")
-
 	switch identifyCloudByRepositoryURI(containerRepository.RepositoryURI) {
 	case GCP:
-		auth.ServerAddress = r.FindString(containerRepository.RepositoryURI)
+		auth.ServerAddress = dockerURIPattern.FindString(containerRepository.RepositoryURI)
 		return nil
 	case AWS:
 		auth.ServerAddress = containerRepository.RepositoryURI


### PR DESCRIPTION
regexp.MustCompile should be a package level var, this will allow for the program to panic on first startup vs in the middle of running. It can also be a performance improvement if the regexp is used in a hot code path as the expression would be compiled every time that piece of code is hit.