### PR TITLE
Bump github-action dependencies and move to go-releaser

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,15 +15,15 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: 1.21
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.52.2
+          version: v1.54.1
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -9,7 +9,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-python@v2
     - uses: pre-commit/action@v2.0.3
       env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,28 +1,28 @@
 name: Generate release-artifacts
 on:
-  release:
-    types:
-      - created
-      - released
+  push:
+    # Pattern matched against refs/tags
+    tags:
+      - '*'
+
+permissions:
+  contents: write
+
 jobs:
-  generate:
-    name: Generate cross-platform builds
+  goreleaser:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        goos: [linux, darwin]
-        goarch: [amd64, arm64]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Release
-        uses: wangyoucao577/go-release-action@v1.31
+      - uses: actions/checkout@v3
         with:
-          overwrite: TRUE
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          goos: ${{ matrix.goos }}
-          goarch: ${{ matrix.goarch }}
-          goversion: 1.19
-          binary_name: mass
-          # ldflags is the canonical way of setting dynamic values (like version) at compile time
-          ldflags: -X github.com/massdriver-cloud/mass/internal/version.version=${{github.ref_name}} -X github.com/massdriver-cloud/mass/internal/version.gitSHA=${{github.sha}}
+          fetch-depth: 0
+      - run: git fetch --force --tags
+      - uses: actions/setup-go@v4
+        with:
+          go-version: 1.21
+      - uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser
+          version: v1.20.0
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,11 +10,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: 1.21
       - name: Build
         run: go build -v ./...
       - name: Test

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ env
 event.json
 preview.demo.json
 TODO
+
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,48 @@
+release:
+  # If set to auto, will mark the release as not ready for production in case there is an indicator for this in the
+  # tag e.g. v1.0.0-rc1 .If set to true, will mark the release as not ready for production.
+  prerelease: auto
+
+builds:
+  - id: linux-build
+    binary: mass
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    ldflags: &build-ldflags |
+      -X github.com/massdriver-cloud/mass/internal/version.version={{.Version}}
+      -X github.com/massdriver-cloud/mass/internal/version.gitSHA={{.FullCommit}}
+
+  - id: darwin-build
+    binary: mass
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags: *build-ldflags
+
+archives:
+  - id: linux-archives
+    builds:
+      - linux-build
+
+  - id: darwin-archives
+    builds:
+      - darwin-build
+
+checksum:
+  name_template: 'checksums.txt'
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'


### PR DESCRIPTION
Example of how the releases will look from my branch: https://github.com/dramich/mass/releases/tag/1.5.0
Note that the changlog is huge because I have no previous tags in my repo to diff. 