### PR TITLE
Remove pushing `latest` image

### DIFF
--- a/internal/commands/image/push.go
+++ b/internal/commands/image/push.go
@@ -61,14 +61,6 @@ func Push(client graphql.Client, input PushImageInput, imageClient Client) error
 		return err
 	}
 
-	if input.Tag != "latest" {
-		input.Tag = "latest"
-		err = pushImage(input, imageClient, containerRepository)
-		if err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
We aren't building the image with the `latest` tag, and therefore docker can't find the `latest` image to push.

I'm not sure how this worked in the first place or what broke it, but this should unblock us.

Mid-term, the correct fix is to expand PushImageInput Tag to be a []string, and add the tag from the tag flag to it, as well as `latest` if the flag tag is not `latest`. This way the tags get passed to both `BuildImage` and `PushImage`.