### PR TITLE
WIP: Update init command to accept env instead of project 

### DIFF
--- a/cmd/helpdocs/preview/init.md
+++ b/cmd/helpdocs/preview/init.md
@@ -4,11 +4,11 @@ The preview environment config file should be checked into your source repositor
 
 **Examples:**
 
-`mass preview init $yourProjectSlug`
+`mass preview init $yourEnvironmentSlug/ID`
 
-`mass preview init ecomm`
+`mass preview init projectSlug-environmentSlug`
 
-`mass preview init ecomm --output path/to/my/preview.json`
+`mass preview init myProject-ecomm --output path/to/my/preview.json`
 
 ## Preview Environment Config Files
 

--- a/cmd/preview.go
+++ b/cmd/preview.go
@@ -64,17 +64,20 @@ func init() {
 }
 
 func runPreviewInit(cmd *cobra.Command, args []string) error {
-	projectSlug := args[0]
+	envSlug := args[0]
 	config, configErr := config.Get()
 	if configErr != nil {
 		return configErr
 	}
+
 	client := api.NewClient(config.URL, config.APIKey)
 
-	initModel, _ := peinit.New(client, config.OrgID, projectSlug)
+	initModel, err := peinit.New(client, config.OrgID, envSlug)
+	if err != nil {
+		return err
+	}
 	p := tea.NewProgram(initModel)
 	result, err := p.Run()
-
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,10 @@ require (
 	github.com/Microsoft/go-winio v0.6.0 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8 // indirect
 	github.com/acomagu/bufpipe v1.0.4 // indirect
+	github.com/agnivade/levenshtein v1.1.1 // indirect
 	github.com/alecthomas/chroma v0.10.0 // indirect
+	github.com/alexflint/go-arg v1.4.2 // indirect
+	github.com/alexflint/go-scalar v1.0.0 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52 v1.2.2 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -62,10 +62,13 @@ github.com/acomagu/bufpipe v1.0.4 h1:e3H4WUzM3npvo5uv95QuJM3cQspFNtFBzvJ2oNjKIDQ
 github.com/acomagu/bufpipe v1.0.4/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/agnivade/levenshtein v1.1.0/go.mod h1:veldBMzWxcCG2ZvUTKD2kJNRdCk5hVbJomOvKkmgYbo=
+github.com/agnivade/levenshtein v1.1.1 h1:QY8M92nrzkmr798gCo3kmMyqXFzdQVpxLlGPRBij0P8=
 github.com/agnivade/levenshtein v1.1.1/go.mod h1:veldBMzWxcCG2ZvUTKD2kJNRdCk5hVbJomOvKkmgYbo=
 github.com/alecthomas/chroma v0.10.0 h1:7XDcGkCQopCNKjZHfYrNLraA+M7e0fMiJ/Mfikbfjek=
 github.com/alecthomas/chroma v0.10.0/go.mod h1:jtJATyUxlIORhUOFNA9NZDWGAQ8wpxQQqNSB4rjA/1s=
+github.com/alexflint/go-arg v1.4.2 h1:lDWZAXxpAnZUq4qwb86p/3rIJJ2Li81EoMbTMujhVa0=
 github.com/alexflint/go-arg v1.4.2/go.mod h1:9iRbDxne7LcR/GSvEr7ma++GLpdIU1zrghf2y2768kM=
+github.com/alexflint/go-scalar v1.0.0 h1:NGupf1XV/Xb04wXskDFzS0KWOLH632W/EO4fAFi+A70=
 github.com/alexflint/go-scalar v1.0.0/go.mod h1:GpHzbCOZXEKMEcygYQ5n/aa4Aq84zbxjy3MxYW0gjYw=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=

--- a/pkg/api/genqlient.graphql
+++ b/pkg/api/genqlient.graphql
@@ -16,6 +16,39 @@ query getProjectById($organizationId: ID!, $id: ID!) {
   }
 }
 
+query GetEnvironmentById($organizationId: ID!, $id: ID!) {
+  environment(organizationId: $organizationId, id: $id) {
+    name
+    slug
+    id
+    project {
+      id
+      defaultParams
+    }
+    packages {
+      id
+      params
+      namePrefix
+      manifest {
+        id
+        name
+        slug
+      }
+      remoteReferences {
+        artifact {
+          id
+        }
+        field
+      }
+      secretFields{
+        name
+        required
+        json
+      }
+    }
+  }
+}
+
 query getDeploymentById($organizationId: ID!, $id: ID!) {
   deployment(organizationId: $organizationId, id: $id) {
     id

--- a/pkg/api/preview_config.go
+++ b/pkg/api/preview_config.go
@@ -17,8 +17,9 @@ type RemoteRef struct {
 	Field      string `json:"field"`
 }
 type Secret struct {
-	Name  string `json:"name"`
-	Value string `json:"value"`
+	Name     string `json:"name"`
+	Value    string `json:"value"`
+	Required bool   `json:"required"`
 }
 
 func (p *PreviewConfig) GetCredentials() []Credential {

--- a/pkg/api/zz_generated.go
+++ b/pkg/api/zz_generated.go
@@ -34,6 +34,313 @@ func (v *Credential) GetArtifactDefinitionType() string { return v.ArtifactDefin
 // GetArtifactId returns Credential.ArtifactId, and is useful for accessing the field via an interface.
 func (v *Credential) GetArtifactId() string { return v.ArtifactId }
 
+// GetEnvironmentByIdEnvironment includes the requested fields of the GraphQL type Environment.
+type GetEnvironmentByIdEnvironment struct {
+	Name     string                                         `json:"name"`
+	Slug     string                                         `json:"slug"`
+	Id       string                                         `json:"id"`
+	Project  GetEnvironmentByIdEnvironmentProject           `json:"project"`
+	Packages []GetEnvironmentByIdEnvironmentPackagesPackage `json:"packages"`
+}
+
+// GetName returns GetEnvironmentByIdEnvironment.Name, and is useful for accessing the field via an interface.
+func (v *GetEnvironmentByIdEnvironment) GetName() string { return v.Name }
+
+// GetSlug returns GetEnvironmentByIdEnvironment.Slug, and is useful for accessing the field via an interface.
+func (v *GetEnvironmentByIdEnvironment) GetSlug() string { return v.Slug }
+
+// GetId returns GetEnvironmentByIdEnvironment.Id, and is useful for accessing the field via an interface.
+func (v *GetEnvironmentByIdEnvironment) GetId() string { return v.Id }
+
+// GetProject returns GetEnvironmentByIdEnvironment.Project, and is useful for accessing the field via an interface.
+func (v *GetEnvironmentByIdEnvironment) GetProject() GetEnvironmentByIdEnvironmentProject {
+	return v.Project
+}
+
+// GetPackages returns GetEnvironmentByIdEnvironment.Packages, and is useful for accessing the field via an interface.
+func (v *GetEnvironmentByIdEnvironment) GetPackages() []GetEnvironmentByIdEnvironmentPackagesPackage {
+	return v.Packages
+}
+
+// GetEnvironmentByIdEnvironmentPackagesPackage includes the requested fields of the GraphQL type Package.
+type GetEnvironmentByIdEnvironmentPackagesPackage struct {
+	Id string `json:"id"`
+	// Package configuration parameters
+	Params     map[string]interface{}                               `json:"-"`
+	NamePrefix string                                               `json:"namePrefix"`
+	Manifest   GetEnvironmentByIdEnvironmentPackagesPackageManifest `json:"manifest"`
+	// Artifacts from a remote source like another project or a resource not managed by massdriver
+	RemoteReferences []GetEnvironmentByIdEnvironmentPackagesPackageRemoteReferencesRemoteReference `json:"remoteReferences"`
+	// Secret configuration for application packages
+	SecretFields []GetEnvironmentByIdEnvironmentPackagesPackageSecretFieldsSecretField `json:"secretFields"`
+}
+
+// GetId returns GetEnvironmentByIdEnvironmentPackagesPackage.Id, and is useful for accessing the field via an interface.
+func (v *GetEnvironmentByIdEnvironmentPackagesPackage) GetId() string { return v.Id }
+
+// GetParams returns GetEnvironmentByIdEnvironmentPackagesPackage.Params, and is useful for accessing the field via an interface.
+func (v *GetEnvironmentByIdEnvironmentPackagesPackage) GetParams() map[string]interface{} {
+	return v.Params
+}
+
+// GetNamePrefix returns GetEnvironmentByIdEnvironmentPackagesPackage.NamePrefix, and is useful for accessing the field via an interface.
+func (v *GetEnvironmentByIdEnvironmentPackagesPackage) GetNamePrefix() string { return v.NamePrefix }
+
+// GetManifest returns GetEnvironmentByIdEnvironmentPackagesPackage.Manifest, and is useful for accessing the field via an interface.
+func (v *GetEnvironmentByIdEnvironmentPackagesPackage) GetManifest() GetEnvironmentByIdEnvironmentPackagesPackageManifest {
+	return v.Manifest
+}
+
+// GetRemoteReferences returns GetEnvironmentByIdEnvironmentPackagesPackage.RemoteReferences, and is useful for accessing the field via an interface.
+func (v *GetEnvironmentByIdEnvironmentPackagesPackage) GetRemoteReferences() []GetEnvironmentByIdEnvironmentPackagesPackageRemoteReferencesRemoteReference {
+	return v.RemoteReferences
+}
+
+// GetSecretFields returns GetEnvironmentByIdEnvironmentPackagesPackage.SecretFields, and is useful for accessing the field via an interface.
+func (v *GetEnvironmentByIdEnvironmentPackagesPackage) GetSecretFields() []GetEnvironmentByIdEnvironmentPackagesPackageSecretFieldsSecretField {
+	return v.SecretFields
+}
+
+func (v *GetEnvironmentByIdEnvironmentPackagesPackage) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*GetEnvironmentByIdEnvironmentPackagesPackage
+		Params json.RawMessage `json:"params"`
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.GetEnvironmentByIdEnvironmentPackagesPackage = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	{
+		dst := &v.Params
+		src := firstPass.Params
+		if len(src) != 0 && string(src) != "null" {
+			err = scalars.UnmarshalJSON(
+				src, dst)
+			if err != nil {
+				return fmt.Errorf(
+					"Unable to unmarshal GetEnvironmentByIdEnvironmentPackagesPackage.Params: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+type __premarshalGetEnvironmentByIdEnvironmentPackagesPackage struct {
+	Id string `json:"id"`
+
+	Params json.RawMessage `json:"params"`
+
+	NamePrefix string `json:"namePrefix"`
+
+	Manifest GetEnvironmentByIdEnvironmentPackagesPackageManifest `json:"manifest"`
+
+	RemoteReferences []GetEnvironmentByIdEnvironmentPackagesPackageRemoteReferencesRemoteReference `json:"remoteReferences"`
+
+	SecretFields []GetEnvironmentByIdEnvironmentPackagesPackageSecretFieldsSecretField `json:"secretFields"`
+}
+
+func (v *GetEnvironmentByIdEnvironmentPackagesPackage) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *GetEnvironmentByIdEnvironmentPackagesPackage) __premarshalJSON() (*__premarshalGetEnvironmentByIdEnvironmentPackagesPackage, error) {
+	var retval __premarshalGetEnvironmentByIdEnvironmentPackagesPackage
+
+	retval.Id = v.Id
+	{
+
+		dst := &retval.Params
+		src := v.Params
+		var err error
+		*dst, err = scalars.MarshalJSON(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Unable to marshal GetEnvironmentByIdEnvironmentPackagesPackage.Params: %w", err)
+		}
+	}
+	retval.NamePrefix = v.NamePrefix
+	retval.Manifest = v.Manifest
+	retval.RemoteReferences = v.RemoteReferences
+	retval.SecretFields = v.SecretFields
+	return &retval, nil
+}
+
+// GetEnvironmentByIdEnvironmentPackagesPackageManifest includes the requested fields of the GraphQL type Manifest.
+type GetEnvironmentByIdEnvironmentPackagesPackageManifest struct {
+	Id   string `json:"id"`
+	Name string `json:"name"`
+	Slug string `json:"slug"`
+}
+
+// GetId returns GetEnvironmentByIdEnvironmentPackagesPackageManifest.Id, and is useful for accessing the field via an interface.
+func (v *GetEnvironmentByIdEnvironmentPackagesPackageManifest) GetId() string { return v.Id }
+
+// GetName returns GetEnvironmentByIdEnvironmentPackagesPackageManifest.Name, and is useful for accessing the field via an interface.
+func (v *GetEnvironmentByIdEnvironmentPackagesPackageManifest) GetName() string { return v.Name }
+
+// GetSlug returns GetEnvironmentByIdEnvironmentPackagesPackageManifest.Slug, and is useful for accessing the field via an interface.
+func (v *GetEnvironmentByIdEnvironmentPackagesPackageManifest) GetSlug() string { return v.Slug }
+
+// GetEnvironmentByIdEnvironmentPackagesPackageRemoteReferencesRemoteReference includes the requested fields of the GraphQL type RemoteReference.
+type GetEnvironmentByIdEnvironmentPackagesPackageRemoteReferencesRemoteReference struct {
+	Artifact GetEnvironmentByIdEnvironmentPackagesPackageRemoteReferencesRemoteReferenceArtifact `json:"artifact"`
+	Field    string                                                                              `json:"field"`
+}
+
+// GetArtifact returns GetEnvironmentByIdEnvironmentPackagesPackageRemoteReferencesRemoteReference.Artifact, and is useful for accessing the field via an interface.
+func (v *GetEnvironmentByIdEnvironmentPackagesPackageRemoteReferencesRemoteReference) GetArtifact() GetEnvironmentByIdEnvironmentPackagesPackageRemoteReferencesRemoteReferenceArtifact {
+	return v.Artifact
+}
+
+// GetField returns GetEnvironmentByIdEnvironmentPackagesPackageRemoteReferencesRemoteReference.Field, and is useful for accessing the field via an interface.
+func (v *GetEnvironmentByIdEnvironmentPackagesPackageRemoteReferencesRemoteReference) GetField() string {
+	return v.Field
+}
+
+// GetEnvironmentByIdEnvironmentPackagesPackageRemoteReferencesRemoteReferenceArtifact includes the requested fields of the GraphQL type Artifact.
+type GetEnvironmentByIdEnvironmentPackagesPackageRemoteReferencesRemoteReferenceArtifact struct {
+	Id string `json:"id"`
+}
+
+// GetId returns GetEnvironmentByIdEnvironmentPackagesPackageRemoteReferencesRemoteReferenceArtifact.Id, and is useful for accessing the field via an interface.
+func (v *GetEnvironmentByIdEnvironmentPackagesPackageRemoteReferencesRemoteReferenceArtifact) GetId() string {
+	return v.Id
+}
+
+// GetEnvironmentByIdEnvironmentPackagesPackageSecretFieldsSecretField includes the requested fields of the GraphQL type SecretField.
+// The GraphQL type's documentation follows.
+//
+// Application secret definitions. These fields are defined in your applications massdriver.yaml file.
+//
+// Secrets are only applied to `application` type bundles.
+type GetEnvironmentByIdEnvironmentPackagesPackageSecretFieldsSecretField struct {
+	// The name of the secret. Generally in the form of an environment variable.
+	Name string `json:"name"`
+	// Is the secret required?
+	Required bool `json:"required"`
+	// Is the secret a JSON object?
+	Json bool `json:"json"`
+}
+
+// GetName returns GetEnvironmentByIdEnvironmentPackagesPackageSecretFieldsSecretField.Name, and is useful for accessing the field via an interface.
+func (v *GetEnvironmentByIdEnvironmentPackagesPackageSecretFieldsSecretField) GetName() string {
+	return v.Name
+}
+
+// GetRequired returns GetEnvironmentByIdEnvironmentPackagesPackageSecretFieldsSecretField.Required, and is useful for accessing the field via an interface.
+func (v *GetEnvironmentByIdEnvironmentPackagesPackageSecretFieldsSecretField) GetRequired() bool {
+	return v.Required
+}
+
+// GetJson returns GetEnvironmentByIdEnvironmentPackagesPackageSecretFieldsSecretField.Json, and is useful for accessing the field via an interface.
+func (v *GetEnvironmentByIdEnvironmentPackagesPackageSecretFieldsSecretField) GetJson() bool {
+	return v.Json
+}
+
+// GetEnvironmentByIdEnvironmentProject includes the requested fields of the GraphQL type Project.
+type GetEnvironmentByIdEnvironmentProject struct {
+	Id            string                 `json:"id"`
+	DefaultParams map[string]interface{} `json:"-"`
+}
+
+// GetId returns GetEnvironmentByIdEnvironmentProject.Id, and is useful for accessing the field via an interface.
+func (v *GetEnvironmentByIdEnvironmentProject) GetId() string { return v.Id }
+
+// GetDefaultParams returns GetEnvironmentByIdEnvironmentProject.DefaultParams, and is useful for accessing the field via an interface.
+func (v *GetEnvironmentByIdEnvironmentProject) GetDefaultParams() map[string]interface{} {
+	return v.DefaultParams
+}
+
+func (v *GetEnvironmentByIdEnvironmentProject) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*GetEnvironmentByIdEnvironmentProject
+		DefaultParams json.RawMessage `json:"defaultParams"`
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.GetEnvironmentByIdEnvironmentProject = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	{
+		dst := &v.DefaultParams
+		src := firstPass.DefaultParams
+		if len(src) != 0 && string(src) != "null" {
+			err = scalars.UnmarshalJSON(
+				src, dst)
+			if err != nil {
+				return fmt.Errorf(
+					"Unable to unmarshal GetEnvironmentByIdEnvironmentProject.DefaultParams: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+type __premarshalGetEnvironmentByIdEnvironmentProject struct {
+	Id string `json:"id"`
+
+	DefaultParams json.RawMessage `json:"defaultParams"`
+}
+
+func (v *GetEnvironmentByIdEnvironmentProject) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *GetEnvironmentByIdEnvironmentProject) __premarshalJSON() (*__premarshalGetEnvironmentByIdEnvironmentProject, error) {
+	var retval __premarshalGetEnvironmentByIdEnvironmentProject
+
+	retval.Id = v.Id
+	{
+
+		dst := &retval.DefaultParams
+		src := v.DefaultParams
+		var err error
+		*dst, err = scalars.MarshalJSON(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Unable to marshal GetEnvironmentByIdEnvironmentProject.DefaultParams: %w", err)
+		}
+	}
+	return &retval, nil
+}
+
+// GetEnvironmentByIdResponse is returned by GetEnvironmentById on success.
+type GetEnvironmentByIdResponse struct {
+	Environment GetEnvironmentByIdEnvironment `json:"environment"`
+}
+
+// GetEnvironment returns GetEnvironmentByIdResponse.Environment, and is useful for accessing the field via an interface.
+func (v *GetEnvironmentByIdResponse) GetEnvironment() GetEnvironmentByIdEnvironment {
+	return v.Environment
+}
+
 // MutationValidationError includes the requested fields of the GraphQL type ValidationMessage.
 // The GraphQL type's documentation follows.
 //
@@ -177,6 +484,18 @@ func (v *PreviewEnvironmentInput) __premarshalJSON() (*__premarshalPreviewEnviro
 	}
 	return &retval, nil
 }
+
+// __GetEnvironmentByIdInput is used internally by genqlient
+type __GetEnvironmentByIdInput struct {
+	OrganizationId string `json:"organizationId"`
+	Id             string `json:"id"`
+}
+
+// GetOrganizationId returns __GetEnvironmentByIdInput.OrganizationId, and is useful for accessing the field via an interface.
+func (v *__GetEnvironmentByIdInput) GetOrganizationId() string { return v.OrganizationId }
+
+// GetId returns __GetEnvironmentByIdInput.Id, and is useful for accessing the field via an interface.
+func (v *__GetEnvironmentByIdInput) GetId() string { return v.Id }
 
 // __configurePackageInput is used internally by genqlient
 type __configurePackageInput struct {
@@ -1317,6 +1636,67 @@ type getProjectByIdResponse struct {
 
 // GetProject returns getProjectByIdResponse.Project, and is useful for accessing the field via an interface.
 func (v *getProjectByIdResponse) GetProject() getProjectByIdProject { return v.Project }
+
+func GetEnvironmentById(
+	ctx context.Context,
+	client graphql.Client,
+	organizationId string,
+	id string,
+) (*GetEnvironmentByIdResponse, error) {
+	req := &graphql.Request{
+		OpName: "GetEnvironmentById",
+		Query: `
+query GetEnvironmentById ($organizationId: ID!, $id: ID!) {
+	environment(organizationId: $organizationId, id: $id) {
+		name
+		slug
+		id
+		project {
+			id
+			defaultParams
+		}
+		packages {
+			id
+			params
+			namePrefix
+			manifest {
+				id
+				name
+				slug
+			}
+			remoteReferences {
+				artifact {
+					id
+				}
+				field
+			}
+			secretFields {
+				name
+				required
+				json
+			}
+		}
+	}
+}
+`,
+		Variables: &__GetEnvironmentByIdInput{
+			OrganizationId: organizationId,
+			Id:             id,
+		},
+	}
+	var err error
+
+	var data GetEnvironmentByIdResponse
+	resp := &graphql.Response{Data: &data}
+
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
+	)
+
+	return &data, err
+}
 
 func configurePackage(
 	ctx context.Context,

--- a/pkg/commands/preview_environment/initialize/initialize_test.go
+++ b/pkg/commands/preview_environment/initialize/initialize_test.go
@@ -12,9 +12,33 @@ import (
 )
 
 func TestRun(t *testing.T) {
-	projectSlug := "ecomm"
+	envSlug := "env1"
+	projectSlug := "ecomm1"
+
+	env := map[string]interface{}{
+		"name": "potato",
+		"slug": "potato",
+		"packages": []map[string]interface{}{
+			{
+				"id": "package1",
+				"manifest": map[string]interface{}{
+					"slug": "database",
+				},
+			},
+		},
+		"project": map[string]interface{}{
+			"id": "ecomma",
+			"defaultParams": map[string]interface{}{
+				"database": map[string]interface{}{
+					"username": "root",
+				},
+			},
+		},
+	}
 
 	responses := []interface{}{
+		gqlmock.MockQueryResponse("environment", env),
+
 		gqlmock.MockQueryResponse("project", map[string]interface{}{
 			"slug": projectSlug,
 			"defaultParams": map[string]interface{}{
@@ -32,7 +56,7 @@ func TestRun(t *testing.T) {
 
 	client := gqlmock.NewClientWithJSONResponseArray(responses)
 
-	model, _ := initialize.New(client, "faux-org-id", projectSlug)
+	model, _ := initialize.New(client, "faux-org-id", envSlug)
 
 	selectRow := tea.KeyMsg{Type: tea.KeySpace}
 	pressNext := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}}


### PR DESCRIPTION
This change updates the init command to take an environment instead of a project
so that default values can be populated from an existing environment.