### PR TITLE
Update server command to serve from a specified dir

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -16,9 +16,11 @@ var (
 )
 
 // RegisterServerHandler registers with the DefaultServeMux to handle requests
-func RegisterServerHandler() {
+func RegisterServerHandler(dir string) {
 	// Register a FileServer that will give access to the assets dir
-	http.Handle("/site/assets/", http.FileServer(http.FS(res)))
+	// http.Handle("/site/assets/", http.FileServer(http.FS(res)))
+
+	http.Handle("/", http.FileServer(http.Dir(dir)))
 
 	// Register the handler func to serve the html page
 	http.HandleFunc("/hello-agent", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This allows the UI to hit the endpoint like `http://127.0.0.1:8080/schema-ui.json` and pickup any of the json schema files (or any other file in the massdriver bundle dir)

`mass server -p 8080 -d massdriver`
