### PR TITLE
Add proxy for massdriver api

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -1,0 +1,26 @@
+package proxy
+
+import (
+	"log/slog"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+)
+
+func New(proxyURL string) (*httputil.ReverseProxy, error) {
+	target, err := url.Parse(proxyURL)
+	if err != nil {
+		return nil, err
+	}
+
+	proxy := &httputil.ReverseProxy{
+		Rewrite: func(r *httputil.ProxyRequest) {
+			r.SetURL(target)
+
+			r.Out.URL.Path = strings.TrimPrefix(r.Out.URL.Path, "/proxy")
+			slog.Debug("Proxying request", "path", r.Out.URL.Path, "method", r.Out.Method)
+		},
+	}
+
+	return proxy, nil
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4,7 +4,11 @@ import (
 	"embed"
 	"html/template"
 	"log"
+	"log/slog"
 	"net/http"
+	"os"
+
+	"github.com/massdriver-cloud/mass/pkg/proxy"
 )
 
 var (
@@ -44,4 +48,12 @@ func RegisterServerHandler(dir string) {
 			return
 		}
 	})
+
+	proxy, err := proxy.New("https://api.massdriver.cloud")
+	if err != nil {
+		slog.Error(err.Error())
+		os.Exit(1)
+	}
+
+	http.Handle("/proxy/", proxy)
 }


### PR DESCRIPTION
This allows the UI to use the proxy to request resources from massdriver and avoid CORS issues.

Use like `curl http://127.0.0.1:8080/proxy/any-endpoint-you-want` which will translate to `https://api.massdriver.cloud/any-endpoint-you-want`