### PR TITLE
Swap yaml library to sigs.k8s.io/yaml

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0
 	golang.org/x/mod v0.9.0
 	golang.org/x/text v0.8.0
-	gopkg.in/yaml.v3 v3.0.1
+	sigs.k8s.io/yaml v1.3.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -816,3 +816,5 @@ rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
+sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
+sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=

--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/massdriver-cloud/mass/pkg/restclient"
 	"github.com/spf13/afero"
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 )
 
 type Handler struct {

--- a/pkg/commands/build_bundle_test.go
+++ b/pkg/commands/build_bundle_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/massdriver-cloud/mass/pkg/mockfilesystem"
 	"github.com/massdriver-cloud/mass/pkg/restclient"
 	"github.com/spf13/afero"
-	"gopkg.in/yaml.v3"
+	"sigs.k8s.io/yaml"
 )
 
 var expectedSchemaContents = map[string][]byte{

--- a/pkg/commands/generate_new_bundle_test.go
+++ b/pkg/commands/generate_new_bundle_test.go
@@ -6,11 +6,12 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/massdriver-cloud/mass/pkg/bundle"
 	"github.com/massdriver-cloud/mass/pkg/commands"
 	"github.com/massdriver-cloud/mass/pkg/mockfilesystem"
 	"github.com/massdriver-cloud/mass/pkg/templatecache"
 	"github.com/spf13/afero"
-	"gopkg.in/yaml.v3"
+	"sigs.k8s.io/yaml"
 )
 
 func TestCopyFilesFromTemplateToCurrentDirectory(t *testing.T) {
@@ -116,7 +117,7 @@ func TestTemplateRender(t *testing.T) {
 
 	checkErr(err, t)
 
-	got := make(map[string]interface{})
+	got := &bundle.Bundle{}
 
 	err = yaml.Unmarshal(renderedTemplate, got)
 
@@ -134,12 +135,12 @@ func TestTemplateRender(t *testing.T) {
 		"required": []interface{}{"aws_authentication", "dynamo"},
 	}
 
-	if got["name"] != templateData.Name {
-		t.Errorf("Expected rendered template's name field to be %s but got %s", templateData.Name, got["name"])
+	if got.Name != templateData.Name {
+		t.Errorf("Expected rendered template's name field to be %s but got %s", templateData.Name, got.Name)
 	}
 
-	if !reflect.DeepEqual(got["connections"], wantConnections) {
-		t.Errorf("Expected rendered template's connections field to be %v but got %v", wantConnections, got["connections"])
+	if !reflect.DeepEqual(got.Connections, wantConnections) {
+		t.Errorf("Expected rendered template's connections field to be %v but got %v", wantConnections, got.Connections)
 	}
 }
 

--- a/pkg/files/files.go
+++ b/pkg/files/files.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/BurntSushi/toml"
-	"gopkg.in/yaml.v3"
+	"sigs.k8s.io/yaml"
 )
 
 const UserRW = 0600


### PR DESCRIPTION
This module is supported and also gives access to easy yaml > json conversion and back which will be needed in the future
This change unblocks the UI as well, when moving the yaml parsing I used the wrong version which broke the bundle yaml unmarshal 

For more context, go-yaml is unmaintained at this point, and k8s is pushing to fork it since it's pretty important https://github.com/kubernetes-sigs/yaml/pull/76