### PR TITLE
Add massdriver dir to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ mass
 .vscode
 bin
 mass
+/massdriver/
 
 .DS_Store
 preview.json


### PR DESCRIPTION
This is the default dir when running `mass bundle new` so add it to help people testing