### PR TITLE
Refactor to use constructor pattern

### DIFF
--- a/cmd/application.go
+++ b/cmd/application.go
@@ -13,54 +13,54 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var appParamsPath = "./params.json"
-var appPatchQueries []string
-var appCmdHelp = mustRenderHelpDoc("application")
-var appDeployCmdHelp = mustRenderHelpDoc("application/deploy")
-var appPatchCmdHelp = mustRenderHelpDoc("application/patch")
-var appConfigureCmdHelp = mustRenderHelpDoc("application/configure")
+var (
+	appParamsPath   = "./params.json"
+	appPatchQueries []string
+)
 
-var appCmd = &cobra.Command{
-	Use:     "application",
-	Aliases: []string{"app"},
-	Short:   "Manage applications",
-	Long:    appCmdHelp,
-}
+func NewCmdApp() *cobra.Command {
+	appCmd := &cobra.Command{
+		Use:     "application",
+		Aliases: []string{"app"},
+		Short:   "Manage applications",
+		Long:    mustRenderHelpDoc("application"),
+	}
 
-var appDeployCmd = &cobra.Command{
-	Use:   `deploy <project>-<target>-<manifest>`,
-	Short: "Deploy applications",
-	Long:  appDeployCmdHelp,
-	Args:  cobra.ExactArgs(1),
-	RunE:  runAppDeploy,
-}
+	appDeployCmd := &cobra.Command{
+		Use:   `deploy <project>-<target>-<manifest>`,
+		Short: "Deploy applications",
+		Long:  mustRenderHelpDoc("application/deploy"),
+		Args:  cobra.ExactArgs(1),
+		RunE:  runAppDeploy,
+	}
 
-var appConfigureCmd = &cobra.Command{
-	Use:     `configure <project>-<target>-<manifest>`,
-	Short:   "Configure application",
-	Aliases: []string{"cfg"},
-	Long:    appConfigureCmdHelp,
-	Args:    cobra.ExactArgs(1),
-	RunE:    runAppConfigure,
-}
+	appConfigureCmd := &cobra.Command{
+		Use:     `configure <project>-<target>-<manifest>`,
+		Short:   "Configure application",
+		Aliases: []string{"cfg"},
+		Long:    mustRenderHelpDoc("application/configure"),
+		Args:    cobra.ExactArgs(1),
+		RunE:    runAppConfigure,
+	}
 
-var appPatchCmd = &cobra.Command{
-	Use:     `patch <project>-<target>-<manifest>`,
-	Short:   "Patch individual package parameter values",
-	Aliases: []string{"cfg"},
-	Long:    appPatchCmdHelp,
-	Args:    cobra.ExactArgs(1),
-	RunE:    runAppPatch,
-}
+	appConfigureCmd.Flags().StringVarP(&appParamsPath, "params", "p", appParamsPath, "Path to params JSON file. This file supports bash interpolation.")
 
-func init() {
-	rootCmd.AddCommand(appCmd)
+	appPatchCmd := &cobra.Command{
+		Use:     `patch <project>-<target>-<manifest>`,
+		Short:   "Patch individual package parameter values",
+		Aliases: []string{"cfg"},
+		Long:    mustRenderHelpDoc("application/patch"),
+		Args:    cobra.ExactArgs(1),
+		RunE:    runAppPatch,
+	}
+
+	appPatchCmd.Flags().StringArrayVarP(&appPatchQueries, "set", "s", []string{}, "Sets a package parameter value using JQ expressions.")
+
 	appCmd.AddCommand(appDeployCmd)
 	appCmd.AddCommand(appConfigureCmd)
 	appCmd.AddCommand(appPatchCmd)
 
-	appConfigureCmd.Flags().StringVarP(&appParamsPath, "params", "p", appParamsPath, "Path to params JSON file. This file supports bash interpolation.")
-	appPatchCmd.Flags().StringArrayVarP(&appPatchQueries, "set", "s", []string{}, "Sets a package parameter value using JQ expressions.")
+	return appCmd
 }
 
 func runAppDeploy(cmd *cobra.Command, args []string) error {

--- a/cmd/artifact.go
+++ b/cmd/artifact.go
@@ -9,30 +9,27 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var artifactCmdHelp = mustRenderHelpDoc("artifact")
-var artifactImportCmdHelp = mustRenderHelpDoc("artifact/import")
+func NewCmdArtifact() *cobra.Command {
+	artifactCmd := &cobra.Command{
+		Use:   "artifact",
+		Short: "Manage artifacts",
+		Long:  mustRenderHelpDoc("artifact"),
+	}
 
-var artifactCmd = &cobra.Command{
-	Use:   "artifact",
-	Short: "Manage artifacts",
-	Long:  artifactCmdHelp,
-}
-
-// Import
-var artifactImportCmd = &cobra.Command{
-	Use:   `import`,
-	Short: "Import a custom artifact",
-	Long:  artifactImportCmdHelp,
-	RunE:  runArtifactImport,
-}
-
-func init() {
-	rootCmd.AddCommand(artifactCmd)
-
-	artifactCmd.AddCommand(artifactImportCmd)
+	// Import
+	artifactImportCmd := &cobra.Command{
+		Use:   `import`,
+		Short: "Import a custom artifact",
+		Long:  mustRenderHelpDoc("artifact/import"),
+		RunE:  runArtifactImport,
+	}
 	artifactImportCmd.Flags().StringP("name", "n", "", "Artifact name")
 	artifactImportCmd.Flags().StringP("type", "t", "", "Artifact type")
 	artifactImportCmd.Flags().StringP("file", "f", "", "Artifact file")
+
+	artifactCmd.AddCommand(artifactImportCmd)
+
+	return artifactCmd
 }
 
 func runArtifactImport(cmd *cobra.Command, args []string) error {

--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -16,78 +16,71 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var bundleCmdHelp = mustRenderHelpDoc("bundle")
+func NewCmdBundle() *cobra.Command {
+	bundleCmd := &cobra.Command{
+		Use:   "bundle",
+		Short: "Generate and publish bundles",
+		Long:  mustRenderHelpDoc("bundle"),
+	}
 
-var bundleTemplateCmdHelp = mustRenderHelpDoc("bundle/template")
+	bundleBuildCmd := &cobra.Command{
+		Use:   "build",
+		Short: "Build schemas from massdriver.yaml file",
+		RunE:  runBundleBuild,
+	}
+	bundleBuildCmd.Flags().StringP("build-directory", "b", ".", "Path to a directory containing a massdriver.yaml file.")
 
-var templateListCmdHelp = mustRenderHelpDoc("bundle/template-list")
+	bundleLintCmd := &cobra.Command{
+		Use:          "lint",
+		Short:        "Check massdriver.yaml file for common errors",
+		SilenceUsage: true,
+		RunE:         runBundleLint,
+	}
+	bundleLintCmd.Flags().StringP("build-directory", "b", ".", "Path to a directory containing a massdriver.yaml file.")
 
-var templateRefreshCmdHelp = mustRenderHelpDoc("bundle/template-refresh")
+	bundleNewCmd := &cobra.Command{
+		Use:   "new",
+		Short: "Create a new bundle from a template",
+		RunE:  runBundleNew,
+	}
 
-var bundleCmd = &cobra.Command{
-	Use:   "bundle",
-	Short: "Generate and publish bundles",
-	Long:  bundleCmdHelp,
-}
+	bundlePublishCmd := &cobra.Command{
+		Use:   "publish",
+		Short: "Publish bundle to Massdriver's package manager",
+		RunE:  runBundlePublish,
+	}
+	bundlePublishCmd.Flags().String("access", "private", "Override the access, useful in CI for deploying to sandboxes.")
+	bundlePublishCmd.Flags().StringP("build-directory", "b", ".", "Path to a directory containing a massdriver.yaml file.")
 
-var bundleTemplateCmd = &cobra.Command{
-	Use:   "template",
-	Short: "Application template development tools",
-	Long:  bundleTemplateCmdHelp,
-}
+	bundleTemplateCmd := &cobra.Command{
+		Use:   "template",
+		Short: "Application template development tools",
+		Long:  mustRenderHelpDoc("bundle/template"),
+	}
 
-var bundleTemplateListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List bundle templates",
-	Long:  templateListCmdHelp,
-	RunE:  runBundleTemplateList,
-}
+	bundleTemplateListCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List bundle templates",
+		Long:  mustRenderHelpDoc("bundle/template-list"),
+		RunE:  runBundleTemplateList,
+	}
 
-var bundleTemplateRefreshCmd = &cobra.Command{
-	Use:   "refresh",
-	Short: "Update template list from the official Massdriver Github",
-	Long:  templateRefreshCmdHelp,
-	RunE:  runBundleTemplateRefresh,
-}
+	bundleTemplateRefreshCmd := &cobra.Command{
+		Use:   "refresh",
+		Short: "Update template list from the official Massdriver Github",
+		Long:  mustRenderHelpDoc("bundle/template-refresh"),
+		RunE:  runBundleTemplateRefresh,
+	}
 
-var bundleNewCmd = &cobra.Command{
-	Use:   "new",
-	Short: "Create a new bundle from a template",
-	RunE:  runBundleNew,
-}
-
-var bundleBuildCmd = &cobra.Command{
-	Use:   "build",
-	Short: "Build schemas from massdriver.yaml file",
-	RunE:  runBundleBuild,
-}
-
-var bundleLintCmd = &cobra.Command{
-	Use:          "lint",
-	Short:        "Check massdriver.yaml file for common errors",
-	SilenceUsage: true,
-	RunE:         runBundleLint,
-}
-
-var bundlePublishCmd = &cobra.Command{
-	Use:   "publish",
-	Short: "Publish bundle to Massdriver's package manager",
-	RunE:  runBundlePublish,
-}
-
-func init() {
-	rootCmd.AddCommand(bundleCmd)
+	bundleCmd.AddCommand(bundleBuildCmd)
+	bundleCmd.AddCommand(bundleLintCmd)
 	bundleCmd.AddCommand(bundleNewCmd)
+	bundleCmd.AddCommand(bundlePublishCmd)
 	bundleCmd.AddCommand(bundleTemplateCmd)
 	bundleTemplateCmd.AddCommand(bundleTemplateListCmd)
 	bundleTemplateCmd.AddCommand(bundleTemplateRefreshCmd)
-	bundleCmd.AddCommand(bundleBuildCmd)
-	bundleBuildCmd.Flags().StringP("build-directory", "b", ".", "Path to a directory containing a massdriver.yaml file.")
-	bundleCmd.AddCommand(bundleLintCmd)
-	bundleLintCmd.Flags().StringP("build-directory", "b", ".", "Path to a directory containing a massdriver.yaml file.")
-	bundleCmd.AddCommand(bundlePublishCmd)
-	bundlePublishCmd.Flags().String("access", "private", "Override the access, useful in CI for deploying to sandboxes.")
-	bundlePublishCmd.Flags().StringP("build-directory", "b", ".", "Path to a directory containing a massdriver.yaml file.")
+
+	return bundleCmd
 }
 
 func runBundleTemplateList(cmd *cobra.Command, args []string) error {

--- a/cmd/image.go
+++ b/cmd/image.go
@@ -10,31 +10,26 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var imagePushCmdHelp = mustRenderHelpDoc("image/push")
-
 type PushFlag struct {
 	Flag      string
 	Attribute *string
 }
 
-var imageCmd = &cobra.Command{
-	Use:   "image",
-	Short: "Container image integration Massdriver",
-}
-
-var imagePushCmd = &cobra.Command{
-	Use:   "push <namespace>/<image-name>",
-	Short: "Push an image to ECR, ACR or GAR",
-	Long:  imagePushCmdHelp,
-	RunE:  runImagePush,
-	Args:  cobra.ExactArgs(1),
-}
-
 var pushInput = image.PushImageInput{}
 
-func init() {
-	rootCmd.AddCommand(imageCmd)
-	imageCmd.AddCommand(imagePushCmd)
+func NewCmdImage() *cobra.Command {
+	imageCmd := &cobra.Command{
+		Use:   "image",
+		Short: "Container image integration Massdriver",
+	}
+
+	imagePushCmd := &cobra.Command{
+		Use:   "push <namespace>/<image-name>",
+		Short: "Push an image to ECR, ACR or GAR",
+		Long:  mustRenderHelpDoc("image/push"),
+		RunE:  runImagePush,
+		Args:  cobra.ExactArgs(1),
+	}
 	imagePushCmd.Flags().StringVarP(&pushInput.DockerBuildContext, "build-context", "b", ".", "Path to the directory to build the image from")
 	imagePushCmd.Flags().StringVarP(&pushInput.Dockerfile, "dockerfile", "f", "Dockerfile", "Name of the dockerfile to build from if you have named it anything other than Dockerfile")
 	imagePushCmd.Flags().StringSliceVarP(&pushInput.Tags, "image-tag", "t", []string{"latest"}, "Unique identifier for this version of the image")
@@ -44,6 +39,10 @@ func init() {
 	_ = imagePushCmd.MarkFlagRequired("region")
 	imagePushCmd.Flags().StringVarP(&pushInput.TargetPlatform, "platform", "p", "linux/amd64", "Set platform if server is multi-platform capable")
 	imagePushCmd.Flags().StringVarP(&pushInput.CacheFrom, "cache-from", "c", "", "Path to image used for caching")
+
+	imageCmd.AddCommand(imagePushCmd)
+
+	return imageCmd
 }
 
 func runImagePush(cmd *cobra.Command, args []string) error {

--- a/cmd/infrastructure.go
+++ b/cmd/infrastructure.go
@@ -13,54 +13,52 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var infraParamsPath = "./params.json"
-var infraPatchQueries []string
-var infraCmdHelp = mustRenderHelpDoc("infrastructure")
-var infraDeployCmdHelp = mustRenderHelpDoc("infrastructure/deploy")
-var infraPatchCmdHelp = mustRenderHelpDoc("infrastructure/patch")
-var infraConfigureCmdHelp = mustRenderHelpDoc("infrastructure/configure")
+var (
+	infraParamsPath   = "./params.json"
+	infraPatchQueries []string
+)
 
-var infraCmd = &cobra.Command{
-	Use:     "infrastructure",
-	Aliases: []string{"infra"},
-	Short:   "Manage infrastructure",
-	Long:    infraCmdHelp,
-}
+func NewCmdInfra() *cobra.Command {
+	infraCmd := &cobra.Command{
+		Use:     "infrastructure",
+		Aliases: []string{"infra"},
+		Short:   "Manage infrastructure",
+		Long:    mustRenderHelpDoc("infrastructure"),
+	}
 
-var infraDeployCmd = &cobra.Command{
-	Use:   `deploy <project>-<target>-<manifest>`,
-	Short: "Deploy infrastructure",
-	Long:  infraDeployCmdHelp,
-	Args:  cobra.ExactArgs(1),
-	RunE:  runInfraDeploy,
-}
+	infraConfigureCmd := &cobra.Command{
+		Use:     `configure <project>-<target>-<manifest>`,
+		Short:   "Configure infrastructure",
+		Aliases: []string{"cfg"},
+		Long:    mustRenderHelpDoc("infrastructure/configure"),
+		Args:    cobra.ExactArgs(1),
+		RunE:    runInfraConfigure,
+	}
+	infraConfigureCmd.Flags().StringVarP(&infraParamsPath, "params", "p", infraParamsPath, "Path to params JSON file. This file supports bash interpolation.")
 
-var infraConfigureCmd = &cobra.Command{
-	Use:     `configure <project>-<target>-<manifest>`,
-	Short:   "Configure infrastructure",
-	Aliases: []string{"cfg"},
-	Long:    infraConfigureCmdHelp,
-	Args:    cobra.ExactArgs(1),
-	RunE:    runInfraConfigure,
-}
+	infraDeployCmd := &cobra.Command{
+		Use:   `deploy <project>-<target>-<manifest>`,
+		Short: "Deploy infrastructure",
+		Long:  mustRenderHelpDoc("infrastructure/deploy"),
+		Args:  cobra.ExactArgs(1),
+		RunE:  runInfraDeploy,
+	}
 
-var infraPatchCmd = &cobra.Command{
-	Use:     `patch <project>-<target>-<manifest>`,
-	Short:   "Patch individual package parameter values",
-	Aliases: []string{"cfg"},
-	Long:    infraPatchCmdHelp,
-	Args:    cobra.ExactArgs(1),
-	RunE:    runInfraPatch,
-}
+	infraPatchCmd := &cobra.Command{
+		Use:     `patch <project>-<target>-<manifest>`,
+		Short:   "Patch individual package parameter values",
+		Aliases: []string{"cfg"},
+		Long:    mustRenderHelpDoc("infrastructure/patch"),
+		Args:    cobra.ExactArgs(1),
+		RunE:    runInfraPatch,
+	}
+	infraPatchCmd.Flags().StringArrayVarP(&infraPatchQueries, "set", "s", []string{}, "Sets a package parameter value using JQ expressions.")
 
-func init() {
-	rootCmd.AddCommand(infraCmd)
-	infraCmd.AddCommand(infraDeployCmd)
 	infraCmd.AddCommand(infraConfigureCmd)
+	infraCmd.AddCommand(infraDeployCmd)
 	infraCmd.AddCommand(infraPatchCmd)
 
-	infraConfigureCmd.Flags().StringVarP(&infraParamsPath, "params", "p", infraParamsPath, "Path to params JSON file. This file supports bash interpolation.")
-	infraPatchCmd.Flags().StringArrayVarP(&infraPatchQueries, "set", "s", []string{}, "Sets a package parameter value using JQ expressions.")
+	return infraCmd
 }
 
 func runInfraDeploy(cmd *cobra.Command, args []string) error {

--- a/cmd/preview.go
+++ b/cmd/preview.go
@@ -14,53 +14,50 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var previewCmdHelp = mustRenderHelpDoc("preview")
-var previewInitCmdHelp = mustRenderHelpDoc("preview/init")
-var previewDeployCmdHelp = mustRenderHelpDoc("preview/deploy")
-var previewDecommissionCmdHelp = mustRenderHelpDoc("preview/decommission")
+var (
+	previewInitParamsPath      = "./preview.json"
+	previewDeployCiContextPath = "/home/runner/work/_temp/_github_workflow/event.json"
+)
 
-var previewInitParamsPath = "./preview.json"
-var previewDeployCiContextPath = "/home/runner/work/_temp/_github_workflow/event.json"
+func NewCmdPreview() *cobra.Command {
+	previewCmd := &cobra.Command{
+		Use:     "preview",
+		Aliases: []string{"pv"},
+		Short:   "Create & deploy preview environments",
+		Long:    mustRenderHelpDoc("preview"),
+	}
 
-var previewCmd = &cobra.Command{
-	Use:     "preview",
-	Aliases: []string{"pv"},
-	Short:   "Create & deploy preview environments",
-	Long:    previewCmdHelp,
-}
-
-var previewInitCmd = &cobra.Command{
-	Use:   `init $projectSlug`,
-	Short: "Generate a preview enviroment configuration file",
-	Long:  previewInitCmdHelp,
-	Args:  cobra.ExactArgs(1),
-	RunE:  runPreviewInit,
-}
-
-var previewDeployCmd = &cobra.Command{
-	Use:   "deploy",
-	Short: "Deploys a preview environment in your project",
-	Long:  previewDeployCmdHelp,
-	RunE:  runPreviewDeploy,
-}
-
-var previewDecommissionCmd = &cobra.Command{
-	Use:   "decommission $projectTargetSlug",
-	Short: "Decommissions a preview environment in your project",
-	Long:  previewDecommissionCmdHelp,
-	RunE:  runPreviewDecommission,
-	Args:  cobra.ExactArgs(1),
-}
-
-func init() {
-	rootCmd.AddCommand(previewCmd)
-
+	previewInitCmd := &cobra.Command{
+		Use:   `init $projectSlug`,
+		Short: "Generate a preview enviroment configuration file",
+		Long:  mustRenderHelpDoc("preview/init"),
+		Args:  cobra.ExactArgs(1),
+		RunE:  runPreviewInit,
+	}
 	previewInitCmd.Flags().StringVarP(&previewInitParamsPath, "output", "o", "./preview.json", "Output path for preview environment params file. This file supports bash interpolation and can be manually edited or programatically modified during CI.")
+
+	previewDeployCmd := &cobra.Command{
+		Use:   "deploy",
+		Short: "Deploys a preview environment in your project",
+		Long:  mustRenderHelpDoc("preview/deploy"),
+		RunE:  runPreviewDeploy,
+	}
+	previewDeployCmd.Flags().StringVarP(&previewInitParamsPath, "params", "p", previewInitParamsPath, "Path to preview environment configuration file. This file supports bash interpolation.")
+	previewDeployCmd.Flags().StringVarP(&previewDeployCiContextPath, "ci-context", "c", previewDeployCiContextPath, "Path to GitHub Actions event.json")
+
+	previewDecommissionCmd := &cobra.Command{
+		Use:   "decommission $projectTargetSlug",
+		Short: "Decommissions a preview environment in your project",
+		Long:  mustRenderHelpDoc("preview/decommission"),
+		RunE:  runPreviewDecommission,
+		Args:  cobra.ExactArgs(1),
+	}
+
 	previewCmd.AddCommand(previewInitCmd)
 	previewCmd.AddCommand(previewDeployCmd)
 	previewCmd.AddCommand(previewDecommissionCmd)
-	previewDeployCmd.Flags().StringVarP(&previewInitParamsPath, "params", "p", previewInitParamsPath, "Path to preview environment configuration file. This file supports bash interpolation.")
-	previewDeployCmd.Flags().StringVarP(&previewDeployCiContextPath, "ci-context", "c", previewDeployCiContextPath, "Path to GitHub Actions event.json")
+
+	return previewCmd
 }
 
 func runPreviewInit(cmd *cobra.Command, args []string) error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,7 +36,15 @@ var rootCmd = &cobra.Command{
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
+	rootCmd.AddCommand(NewCmdApp())
+	rootCmd.AddCommand(NewCmdArtifact())
+	rootCmd.AddCommand(NewCmdBundle())
+	rootCmd.AddCommand(NewCmdImage())
+	rootCmd.AddCommand(NewCmdInfra())
+	rootCmd.AddCommand(NewCmdPreview())
+	rootCmd.AddCommand(NewCmdSchema())
 	rootCmd.AddCommand(NewCmdServer())
+	rootCmd.AddCommand(NewCmdVersion())
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/cmd/schema.go
+++ b/cmd/schema.go
@@ -8,27 +8,25 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var schemaCmdHelp = mustRenderHelpDoc("schema")
-var schemaValidateCmdHelp = mustRenderHelpDoc("schema/validate")
-var schemaCmd = &cobra.Command{
-	Use:   "schema",
-	Short: "Manage JSON Schemas",
-	Long:  schemaCmdHelp,
-}
+func NewCmdSchema() *cobra.Command {
+	schemaCmd := &cobra.Command{
+		Use:   "schema",
+		Short: "Manage JSON Schemas",
+		Long:  mustRenderHelpDoc("schema"),
+	}
 
-var schemaValidateCmd = &cobra.Command{
-	Use:   "validate",
-	Short: "Validates a JSON document against a JSON Schema",
-	Long:  schemaValidateCmdHelp,
-	RunE:  runSchemaValidate,
-}
-
-func init() {
-	rootCmd.AddCommand(schemaCmd)
-	schemaCmd.AddCommand(schemaValidateCmd)
-
+	schemaValidateCmd := &cobra.Command{
+		Use:   "validate",
+		Short: "Validates a JSON document against a JSON Schema",
+		Long:  mustRenderHelpDoc("schema/validate"),
+		RunE:  runSchemaValidate,
+	}
 	schemaValidateCmd.Flags().StringP("document", "d", "document.json", "Path to JSON document")
 	schemaValidateCmd.Flags().StringP("schema", "s", "./schema.json", "Path to JSON Schema")
+
+	schemaCmd.AddCommand(schemaValidateCmd)
+
+	return schemaCmd
 }
 
 func runSchemaValidate(cmd *cobra.Command, args []string) error {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -9,26 +9,27 @@ import (
 )
 
 // versionCmd represents the version command
-var versionCmd = &cobra.Command{
-	Use:     "version",
-	Aliases: []string{"v"},
-	Short:   "Version of Mass CLI",
-	Long:    ``,
-	RunE:    runVersion,
+func NewCmdVersion() *cobra.Command {
+	versionCmd := &cobra.Command{
+		Use:     "version",
+		Aliases: []string{"v"},
+		Short:   "Version of Mass CLI",
+		Long:    ``,
+		Run:     runVersion,
+	}
+	return versionCmd
 }
 
-func runVersion(cmd *cobra.Command, args []string) error {
-	isOld, _, err := version.CheckForNewerVersionAvailable()
+func runVersion(cmd *cobra.Command, args []string) {
+	latestVersion, err := version.GetLatestVersion()
 	if err != nil {
-		fmt.Printf("could not check for newer versions at %v: %v. skipping...\n", version.LatestReleaseURL, err.Error())
-	} else if isOld {
+		fmt.Printf("Could not check for newer version, skipping. url:%s error:%s", version.LatestReleaseURL, err.Error())
+		return
+	}
+	isOld, _ := version.CheckForNewerVersionAvailable(latestVersion)
+	if isOld {
 		fmt.Printf("A newer version of the CLI is available, you can download it here: %v\n", version.LatestReleaseURL)
 	}
-	var massVersionColor = prettylogs.Green(version.MassVersion())
+	massVersionColor := prettylogs.Green(version.MassVersion())
 	fmt.Printf("Mass CLI version: %v (git SHA: %v) \n", massVersionColor, version.MassGitSHA())
-	return nil
-}
-
-func init() {
-	rootCmd.AddCommand(versionCmd)
 }

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -12,41 +12,31 @@ func TestCheckForNewerVersionAvailable(t *testing.T) {
 		current   string
 		latest    string
 		wantIsOld bool
-		wantErr   bool
 	}{
 		{
 			name:      "unknown version should be considered old",
 			current:   "unknown",
 			latest:    "v1.2.0",
 			wantIsOld: true,
-			wantErr:   false,
 		},
 		{
 			name:      "current version is the latest version",
 			current:   "1.2.0",
 			latest:    "v1.2.0",
 			wantIsOld: false,
-			wantErr:   false,
 		},
 		{
 			name:      "current version is older than the latest version",
 			current:   "1.0.0",
 			latest:    "v1.2.0",
 			wantIsOld: true,
-			wantErr:   false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			version.SetVersion(tt.current)
-			version.GetLatestVersion = func() (string, error) {
-				return tt.latest, nil
-			}
-			got, latestVersion, err := version.CheckForNewerVersionAvailable()
-			if (err != nil) != tt.wantErr {
-				t.Errorf("CheckForNewerVersionAvailable() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
+
+			got, latestVersion := version.CheckForNewerVersionAvailable(tt.latest)
 			if got != tt.wantIsOld {
 				t.Errorf("CheckForNewerVersionAvailable() got = %v, want %v", got, tt.wantIsOld)
 			}


### PR DESCRIPTION
Remove init functions and vars
Move instantiaion into function calls
This allows control over the order in which things get instantiated and the ability to process args/envs before inits are called