### PR TITLE
Adding support for multiple template sources

### DIFF
--- a/docs/helpdocs/bundle/template-refresh.md
+++ b/docs/helpdocs/bundle/template-refresh.md
@@ -19,16 +19,6 @@ export MD_TEMPLATES_PATH="$HOME/custom/"
 mass bundle template refresh
 ```
 
-#### Developing Templates
-
-For local development of templates its common to set:
-
-```shell
-export_MD_TEMPLATES_PATH="."
-mass bundle template list
-mass bundle new
-```
-
 **Note: No `refresh` is necessary here since the templates are in this directory already.**
 
 ### Custom Application Templates

--- a/docs/helpdocs/bundle/template-refresh.md
+++ b/docs/helpdocs/bundle/template-refresh.md
@@ -19,6 +19,18 @@ export MD_TEMPLATES_PATH="$HOME/custom/"
 mass bundle template refresh
 ```
 
+#### Developing Templates
+
+For local development of templates its common to set:
+
+```shell
+export_MD_TEMPLATES_PATH="."
+mass bundle template list
+mass bundle new
+```
+
+**Note: No `refresh` is necessary here since the templates are in this directory already.**
+
 ### Custom Application Templates
 
 You can also manage your own application templates for your teams.
@@ -38,7 +50,7 @@ Official templates can be used as a reference:
 
 #### Overriding Template Source Repos
 
-`MD_TEMPLATES_SRCS` can be set to a comma-separated list of GitHub repo URLs.
+Some teams may have multiple repos of templates, if you need to add additional source repositories `MD_TEMPLATES_SRCS` can be set to a comma-separated list of GitHub repo URLs.
 
 ```shell
 MD_TEMPLATES_SRCS="https://github.com/foo-corp/api-templates,https://github.com/bar-corp/ml-templates"

--- a/docs/helpdocs/bundle/template-refresh.md
+++ b/docs/helpdocs/bundle/template-refresh.md
@@ -1,7 +1,8 @@
 # List Available Templates.
 
-Sync local templates cache with the [official Massdriver templates repository](https://github.com/massdriver-cloud/application-templates). Custom directories can be set for development by
-setting the `MD_TEMPLATES_PATH` to your desired directory
+Sync local templates cache with the [official Massdriver templates repository](https://github.com/massdriver-cloud/application-templates).
+
+The cache directory can be changed by setting the `MD_TEMPLATES_PATH` to your desired directory.
 
 ## Examples
 
@@ -9,9 +10,45 @@ setting the `MD_TEMPLATES_PATH` to your desired directory
 mass bundle template refresh
 ```
 
-### With developer override
+### Override Local Template Cache Directory
+
+By default templates are locally cached at `$HOME/.massdriver`.
 
 ```shell
-export MD_TEMPLATES_PATH=$HOME/custom/
+export MD_TEMPLATES_PATH="$HOME/custom/"
+mass bundle template refresh
+```
+
+### Custom Application Templates
+
+You can also manage your own application templates for your teams.
+
+They are expected to be hosted at a git accessible HTTP address. A simple naming convention and path structure is required. Templates must be top level directories in your repo with a `massdriver.yaml` file.
+
+Like:
+
+- `express-js/massdriver.yaml`
+- `ruby-on-rails/massdriver.yaml`
+- `company-name-standard-golang-service/massdriver.yaml`
+
+Official templates can be used as a reference:
+
+* https://github.com/massdriver-cloud/application-templates/tree/main/rails-kubernetes
+* https://github.com/massdriver-cloud/application-templates/tree/main/aws-lambda
+
+#### Overriding Template Source Repos
+
+`MD_TEMPLATES_SRCS` can be set to a comma-separated list of GitHub repo URLs.
+
+```shell
+MD_TEMPLATES_SRCS="https://github.com/foo-corp/api-templates,https://github.com/bar-corp/ml-templates"
+```
+
+Full example:
+
+```shell
+export MD_TEMPLATES_PATH="$HOME/custom/"
+# Note you'll need to explictly add Massdriver official templates in if youd like to continue using them when overridding
+export MD_TEMPLATES_SRCS="https://github.com/my-org/templates,https://github.com/massdriver-cloud/application-templates"
 mass bundle template refresh
 ```

--- a/pkg/templatecache/bundle_template_cache.go
+++ b/pkg/templatecache/bundle_template_cache.go
@@ -11,17 +11,13 @@ import (
 	"github.com/spf13/afero"
 )
 
-/*
-Adding additional repositories will create the appropriate subdirectories and list
-them accordingly in bunde templates list. In the future this should be read form .massrc.
-*/
-var massdriverApplicationTemplatesRepositories = []string{
-	"https://github.com/massdriver-cloud/application-templates",
-}
-
 const gitOrg = "*"
 const repoName = "*"
 const templateDir = "*"
+
+var defaultApplicationTemplatesRepositories = []string{
+	"https://github.com/massdriver-cloud/application-templates",
+}
 
 type BundleTemplateCache struct {
 	TemplatePath string
@@ -37,6 +33,20 @@ type TemplateList struct {
 type CloneError struct {
 	Repository string
 	Error      string
+}
+
+/*
+Adding additional repositories will create the appropriate subdirectories and list
+them accordingly in bunde templates list. In the future this should be read form .massrc.
+*/
+func massdriverApplicationTemplatesRepositories() []string {
+	templateSrcs := os.Getenv("MD_TEMPLATES_SRCS")
+
+	if templateSrcs == "" {
+		return defaultApplicationTemplatesRepositories
+	}
+
+	return strings.Split(templateSrcs, ",")
 }
 
 // Refresh available templates from Massdriver official Github repository.

--- a/pkg/templatecache/github_fetcher.go
+++ b/pkg/templatecache/github_fetcher.go
@@ -12,8 +12,10 @@ import (
 func GithubTemplatesFetcher(writePath string) error {
 	cloneErrors := []CloneError{}
 
-	for _, repoName := range massdriverApplicationTemplatesRepositories {
+	for _, repoName := range massdriverApplicationTemplatesRepositories() {
+		fmt.Printf("\tCloning %s\n", repoName)
 		cloneErr := doClone(repoName, writePath)
+
 		// If one repository fails, we want to get the rest so stash the error and handle later.
 		if cloneErr != nil {
 			errorStruct := CloneError{Repository: repoName, Error: cloneErr.Error()}


### PR DESCRIPTION
I'm working on some beta templates for an integration and I needed the ability to set multiple git sources.

Todo: show full template name ... it currently just show "rails-kubernetes" but not the repo it came from. Also current main, when generation happens it has lost the git org/repo name and just uses a hard coded value
