### PR TITLE
Add generation validation to github action

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,3 +19,20 @@ jobs:
         run: go build -v ./...
       - name: Test
         run: go test -v ./...
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.21
+      - name: Generate docs
+        run: go run main.go docs
+      - name: Test for changes
+        run: |
+          if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+            git status --porcelain --untracked-files=no
+            echo "Generated docs changes not commited! Run 'mass docs' and commit changes"
+            exit 1
+          fi


### PR DESCRIPTION
The action will run `mass docs` and fail if it finds a difference. 