### PR TITLE
Always show help for preview init

### DIFF
--- a/pkg/commands/preview_environment/initialize/main.go
+++ b/pkg/commands/preview_environment/initialize/main.go
@@ -53,5 +53,7 @@ func New(client graphql.Client, orgID string, projectSlug string) (*Model, error
 		},
 	}
 
+	m.help.ShowAll = true
+
 	return &m, nil
 }


### PR DESCRIPTION
Currently the help for next and back don't show up unless a user pushes `?`, this change always shows the keyboard commands now. 