### PR TITLE
Drop container log timeout

### DIFF
--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -129,9 +129,7 @@ func (h *Handler) StreamLogs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Just in case....
-	ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
-	defer cancel()
+	ctx := r.Context()
 
 	reader, err := h.dockerCLI.ContainerLogs(ctx, containerID, types.ContainerLogsOptions{
 		ShowStderr: true,


### PR DESCRIPTION
This timeout causes the log read to stop and kills the websocket. It was added as safety for local testing but shouldn't be needed anymore. 