### PR TITLE
Assertion check for properties

### DIFF
--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -256,6 +256,23 @@ func unmarshalBundleandApplyDefaults(readDirectory string, cmd *cobra.Command, f
 		bundle.ApplyAppBlockDefaults(unmarshalledBundle)
 	}
 
+	// This looks weird but we have to be careful we don't overwrite things that do exist in the bundle file
+	if unmarshalledBundle.Connections == nil {
+		unmarshalledBundle.Connections = make(map[string]any)
+	}
+
+	if unmarshalledBundle.Connections["properties"] == nil {
+		unmarshalledBundle.Connections["properties"] = make(map[string]any)
+	}
+
+	if unmarshalledBundle.Artifacts == nil {
+		unmarshalledBundle.Artifacts = make(map[string]any)
+	}
+
+	if unmarshalledBundle.Artifacts["properties"] == nil {
+		unmarshalledBundle.Artifacts["properties"] = make(map[string]any)
+	}
+
 	return unmarshalledBundle, nil
 }
 

--- a/pkg/terraform/generate_files.go
+++ b/pkg/terraform/generate_files.go
@@ -69,7 +69,14 @@ func generateTfVarsFiles(buildPath, stepPath string, b *bundle.Bundle, fs afero.
 	for _, task := range varFileTasks {
 		schemaRequiredProperties := createRequiredPropertiesMap(task.schema)
 
-		content, err := transpile(task.schema["properties"].(map[string]interface{}), schemaRequiredProperties)
+		props, ok := task.schema["properties"].(map[string]interface{})
+		if !ok {
+			// We should not hit this now since we are defaulting properties in the bundle
+			// unmarshal so if we do get here, we want to know.
+			return fmt.Errorf("%s block is missing 'properties' entry", task.label)
+		}
+
+		content, err := transpile(props, schemaRequiredProperties)
 
 		if err != nil {
 			return err


### PR DESCRIPTION
Add an assertion check to stop the panic if the field is missing
Add a nice error message to help people find the issue `Error: connections block is missing 'properties' entry`
Default both connections and artifacts to have empty props fields if they don't exist