### PR TITLE
Allow optional usage of the docker buildkit

### DIFF
--- a/cmd/image.go
+++ b/cmd/image.go
@@ -40,7 +40,7 @@ func NewCmdImage() *cobra.Command {
 	_ = imagePushCmd.MarkFlagRequired("region")
 	imagePushCmd.Flags().StringVarP(&pushInput.TargetPlatform, "platform", "p", "linux/amd64", "Set platform if server is multi-platform capable")
 	imagePushCmd.Flags().StringVarP(&pushInput.CacheFrom, "cache-from", "c", "", "Path to image used for caching")
-	imagePushCmd.Flags().BoolVarP(&pushInput.UseBuildkit, "use-builtkit", "x", true, "Use the build kit for docker builds")
+	imagePushCmd.Flags().BoolVarP(&pushInput.UseBuildKit, "use-builtkit", "x", false, "Use the build kit for docker builds")
 
 	imageCmd.AddCommand(imagePushCmd)
 

--- a/cmd/image.go
+++ b/cmd/image.go
@@ -40,6 +40,7 @@ func NewCmdImage() *cobra.Command {
 	_ = imagePushCmd.MarkFlagRequired("region")
 	imagePushCmd.Flags().StringVarP(&pushInput.TargetPlatform, "platform", "p", "linux/amd64", "Set platform if server is multi-platform capable")
 	imagePushCmd.Flags().StringVarP(&pushInput.CacheFrom, "cache-from", "c", "", "Path to image used for caching")
+	imagePushCmd.Flags().BoolVarP(&pushInput.UseBuildkit, "use-builtkit", "x", true, "Use the build kit for docker builds")
 
 	imageCmd.AddCommand(imagePushCmd)
 

--- a/pkg/commands/image/docker_client.go
+++ b/pkg/commands/image/docker_client.go
@@ -61,7 +61,7 @@ func (c *Client) BuildImage(input PushImageInput, containerRepository *api.Conta
 	}
 
 	if input.UseBuildkit {
-		opts.Version = "1"
+		opts.Version = types.BuilderBuildKit
 	}
 
 	if input.CacheFrom != "" {

--- a/pkg/commands/image/docker_client.go
+++ b/pkg/commands/image/docker_client.go
@@ -60,6 +60,10 @@ func (c *Client) BuildImage(input PushImageInput, containerRepository *api.Conta
 		Platform:   input.TargetPlatform,
 	}
 
+	if input.UseBuildkit {
+		opts.Version = "1"
+	}
+
 	if input.CacheFrom != "" {
 		opts.CacheFrom = []string{input.CacheFrom}
 	}

--- a/pkg/commands/image/docker_client.go
+++ b/pkg/commands/image/docker_client.go
@@ -60,7 +60,7 @@ func (c *Client) BuildImage(input PushImageInput, containerRepository *api.Conta
 		Platform:   input.TargetPlatform,
 	}
 
-	if input.UseBuildkit {
+	if input.UseBuildKit {
 		opts.Version = types.BuilderBuildKit
 	}
 

--- a/pkg/commands/image/image.go
+++ b/pkg/commands/image/image.go
@@ -10,7 +10,7 @@ type PushImageInput struct {
 	DockerBuildContext string
 	TargetPlatform     string
 	CacheFrom          string
-	UseBuildkit        bool
+	UseBuildKit        bool
 }
 
 type ErrorLine struct {

--- a/pkg/commands/image/image.go
+++ b/pkg/commands/image/image.go
@@ -10,6 +10,7 @@ type PushImageInput struct {
 	DockerBuildContext string
 	TargetPlatform     string
 	CacheFrom          string
+	UseBuildkit        bool
 }
 
 type ErrorLine struct {


### PR DESCRIPTION
Hi there,

I'm no Go developer, but I had a go anyway!

I need buildkit for an image I'm building. I'm hoping that this PR is safe to test as it only adds the version if the `use-builtkit` variable is set to true. 

I haven't tested as I'm not too sure how
