### PR TITLE
Add flag to image push to skip build

### DIFF
--- a/cmd/image.go
+++ b/cmd/image.go
@@ -40,6 +40,7 @@ func NewCmdImage() *cobra.Command {
 	_ = imagePushCmd.MarkFlagRequired("region")
 	imagePushCmd.Flags().StringVarP(&pushInput.TargetPlatform, "platform", "p", "linux/amd64", "Set platform if server is multi-platform capable")
 	imagePushCmd.Flags().StringVarP(&pushInput.CacheFrom, "cache-from", "c", "", "Path to image used for caching")
+	imagePushCmd.Flags().BoolVarP(&pushInput.SkipBuild, "skip-build", "s", false, "Skip building the image before pushing")
 
 	imageCmd.AddCommand(imagePushCmd)
 

--- a/docs/generated/mass_image_push.md
+++ b/docs/generated/mass_image_push.md
@@ -12,15 +12,25 @@ Push an image to ECR, ACR or GAR
 
 # Push Container Images To Cloud Repositories
 
-Create registries, repositories and push images via the Massdriver CLI. Massdriver will build a Docker registry if it does not exist in the region in which you are pushing an image, create a repository in that region's registry and finally push a tagged version of the image to that repository.
+Create registries, repositories and push images via the Massdriver CLI. Massdriver will build a Docker registry if it does not exist in the region in which you are pushing an image, create a repository in that region's registry and finally push a tagged version of the image to that repository. By default `mass` will attempt to build your image before pushing it. To disable this feature pass the `--skip-build` flag.
 
 ## Examples
 
+Build and push an image:
 ```bash
 mass image push massdriver-cloud/massdriver \
     --region us-east-1 \
     --artifact xxxx \
     --tag v1
+```
+
+Push an existing image and tag without building:
+```bash
+mass image push massdriver-cloud/massdriver \
+    --region us-east-1 \
+    --artifact xxxx \
+    --tag v1 \
+    --skip-build
 ```
 
 In the above example massdriver would create a registry with the namespace provided, and push your built container as the image name in that registry. The artifact ID is a unique idenifier for a credential artifact in Massdriver that is authorized to access the cloud account you are pushing the image to. The tag is the image tag which can be used to signal container orchestration systems which version of the image to pull.
@@ -41,6 +51,7 @@ mass image push <namespace>/<image-name> [flags]
   -t, --image-tag strings      Unique identifier for this version of the image (default [latest])
   -p, --platform string        Set platform if server is multi-platform capable (default "linux/amd64")
   -r, --region string          Cloud region to push the image to
+  -s, --skip-build             Skip building the image before pushing
 ```
 
 ### SEE ALSO

--- a/docs/helpdocs/image/push.md
+++ b/docs/helpdocs/image/push.md
@@ -1,14 +1,24 @@
 # Push Container Images To Cloud Repositories
 
-Create registries, repositories and push images via the Massdriver CLI. Massdriver will build a Docker registry if it does not exist in the region in which you are pushing an image, create a repository in that region's registry and finally push a tagged version of the image to that repository.
+Create registries, repositories and push images via the Massdriver CLI. Massdriver will build a Docker registry if it does not exist in the region in which you are pushing an image, create a repository in that region's registry and finally push a tagged version of the image to that repository. By default `mass` will attempt to build your image before pushing it. To disable this feature pass the `--skip-build` flag.
 
 ## Examples
 
+Build and push an image:
 ```bash
 mass image push massdriver-cloud/massdriver \
     --region us-east-1 \
     --artifact xxxx \
     --tag v1
+```
+
+Push an existing image and tag without building:
+```bash
+mass image push massdriver-cloud/massdriver \
+    --region us-east-1 \
+    --artifact xxxx \
+    --tag v1 \
+    --skip-build
 ```
 
 In the above example massdriver would create a registry with the namespace provided, and push your built container as the image name in that registry. The artifact ID is a unique idenifier for a credential artifact in Massdriver that is authorized to access the cloud account you are pushing the image to. The tag is the image tag which can be used to signal container orchestration systems which version of the image to pull.

--- a/pkg/commands/image/image.go
+++ b/pkg/commands/image/image.go
@@ -10,6 +10,7 @@ type PushImageInput struct {
 	DockerBuildContext string
 	TargetPlatform     string
 	CacheFrom          string
+	SkipBuild          bool
 }
 
 type ErrorLine struct {

--- a/pkg/commands/image/push.go
+++ b/pkg/commands/image/push.go
@@ -36,12 +36,12 @@ func Push(client graphql.Client, input PushImageInput, imageClient Client) error
 	msg = fmt.Sprintf("%s credentials fetched successfully", logCloud)
 	fmt.Println(msg)
 
-	err = imageClient.BuildImage(input, containerRepository)
-	if err != nil {
-		return err
+	if !input.SkipBuild {
+		err = imageClient.BuildImage(input, containerRepository)
+		if err != nil {
+			return err
+		}
 	}
-
-	fmt.Println("Pushing image to repository. This may take a few minutes")
 
 	return imageClient.PushImage(input, containerRepository)
 }

--- a/pkg/commands/image/push_test.go
+++ b/pkg/commands/image/push_test.go
@@ -36,6 +36,10 @@ func (mockCli) ImagePush(ctx context.Context, image string, options types.ImageP
 	return NopCloser(bytes.NewBuffer(make([]byte, 0))), nil
 }
 
+func (mockCli) ImageTag(ctx context.Context, source, target string) error {
+	return nil
+}
+
 type mockGQLClient struct{}
 
 func (mockGQLClient) MakeRequest(ctx context.Context, req *graphql.Request, resp *graphql.Response) error {


### PR DESCRIPTION
The default behavior is kept if the flag is not used so images will continue to be built. 