### PR TITLE
Add browser flag when launching server 

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -33,6 +33,7 @@ func NewCmdServer() *cobra.Command {
 	cmd.Flags().StringP("port", "p", "8080", "port for the server to listen on")
 	cmd.Flags().StringP("directory", "d", "", "directory for the massdriver bundle, will default to the directory the server is ran from")
 	cmd.Flags().String("log-level", "info", "Set the log level for the server. Options are [debug, info, warn, error]")
+	cmd.Flags().Bool("browser", false, "Launch a browser window after starting the server")
 
 	return cmd
 }
@@ -90,7 +91,13 @@ func runServer(cmd *cobra.Command) {
 
 	handleSignals(ctx, server)
 
-	if err = server.Start(port); err != nil {
+	launchBrowser, err := cmd.Flags().GetBool("browser")
+	if err != nil {
+		slog.Error(err.Error())
+		os.Exit(1)
+	}
+
+	if err = server.Start(port, launchBrowser); err != nil {
 		// The signal handler will shutdown the server under a ctrl-c
 		// so getting a ErrServerClosed here is expected
 		if !errors.Is(err, http.ErrServerClosed) {

--- a/docs/generated/mass_server.md
+++ b/docs/generated/mass_server.md
@@ -19,6 +19,7 @@ mass server [flags]
 ### Options
 
 ```
+      --browser            Launch a browser window after starting the server
   -d, --directory string   directory for the massdriver bundle, will default to the directory the server is ran from
   -h, --help               help for server
       --log-level string   Set the log level for the server. Options are [debug, info, warn, error] (default "info")

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/charmbracelet/bubbletea v0.23.2
 	github.com/charmbracelet/glamour v0.6.0
 	github.com/charmbracelet/lipgloss v0.6.0
+	github.com/cli/browser v1.3.0
 	github.com/docker/docker v24.0.8+incompatible
 	github.com/evertras/bubble-table v0.14.8
 	github.com/go-git/go-git/v5 v5.11.0

--- a/go.sum
+++ b/go.sum
@@ -153,6 +153,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWsoZXJNW3xEE4JJyHa5Q25/sd8=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/cilium/ebpf v0.7.0/go.mod h1:/oI2+1shJiTGAMgl6/RgJr36Eo1jzrRcAWbcXO2usCA=
+github.com/cli/browser v1.3.0 h1:LejqCrpWr+1pRqmEPDGnTZOjsMe7sehifLynZJuqJpo=
+github.com/cli/browser v1.3.0/go.mod h1:HH8s+fOAxjhQoBUAsKuPCbqUuxZDhQ2/aD+SzsEfBTk=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/circl v1.3.3/go.mod h1:5XYMA4rFBvNIrhs50XuiBJ15vF2pZn4nnUKZrLbUZFA=
 github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=


### PR DESCRIPTION
If the flag `--browser` is added, then the cli will attempt to open the bundle UI in a browser