### PR TITLE
Removing two misleading log msgs.

### DIFF
--- a/pkg/commands/publish/main.go
+++ b/pkg/commands/publish/main.go
@@ -30,9 +30,6 @@ func Run(b *bundle.Bundle, c *restclient.MassdriverClient, fs afero.Fs, buildFro
 		return err
 	}
 
-	msg = fmt.Sprintf("%s published successfully to with %s visibility", bundleName, access)
-	fmt.Println(msg)
-
 	var buf bytes.Buffer
 
 	msg = fmt.Sprintf("Packaging bundle %s for package manager", bundleName)

--- a/pkg/jsonschema/dereference.go
+++ b/pkg/jsonschema/dereference.go
@@ -59,8 +59,6 @@ func Dereference(anyVal interface{}, opts DereferenceOptions) (interface{}, erro
 			} else if httpPattern.MatchString(schemaRefValue) {
 				// HTTP ref. Pull the schema down via HTTP GET and hydrate
 				hydratedSchema, err = dereferenceHTTPRef(hydratedSchema, schema, schemaRefValue, opts)
-			} else if fragmentPattern.MatchString(schemaRefValue) {
-				fmt.Println("Fragment refs not supported")
 			} else if massdriverDefinitionPattern.MatchString(schemaRefValue) {
 				// this must be a published schema, so fetch from massdriver
 				hydratedSchema, err = dereferenceMassdriverRef(hydratedSchema, schema, schemaRefValue, opts)

--- a/pkg/jsonschema/dereference.go
+++ b/pkg/jsonschema/dereference.go
@@ -26,7 +26,6 @@ type DereferenceOptions struct {
 var relativeFilePathPattern = regexp.MustCompile(`^(\.\/|\.\.\/)`)
 var massdriverDefinitionPattern = regexp.MustCompile(`^[a-zA-Z0-9]`)
 var httpPattern = regexp.MustCompile(`^(http|https)://`)
-var fragmentPattern = regexp.MustCompile(`^#`)
 
 func Dereference(anyVal interface{}, opts DereferenceOptions) (interface{}, error) {
 	val := getValue(anyVal)


### PR DESCRIPTION
* We emit an early "bundle published" message
* We do support fragments, we just don't do anything _to_ them