### PR TITLE
Fixing handling of bundle new error

### DIFF
--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -199,7 +199,7 @@ func runBundleNew(input *bundleNew) {
 
 	c, configErr := config.Get()
 	if configErr != nil {
-		log.Fatal(err)
+		log.Fatal(configErr)
 	}
 	gqlclient := api.NewClient(c.URL, c.APIKey)
 


### PR DESCRIPTION
Current issue and why it needs to be fixed:
```
❯ ../mass/bin/mass-linux-amd64 bundle new
2024/06/24 10:43:20 INFO Refreshing templates path=/home/michael/.massdriver
2024/06/24 10:43:20 INFO Templates are current, skipping download
2024/06/24 10:43:20 <nil>
```

Test results:
```
❯ ../mass/bin/mass-linux-amd64 bundle new
2024/06/24 11:02:32 INFO Refreshing templates path=/home/michael/.massdriver
2024/06/24 11:02:32 INFO Templates are current, skipping download
2024/06/24 11:02:32 required environment variable not set: OrgID: missing required value: MASSDRIVER_ORG_ID
```
and for API key, after setting ORG_ID
```
❯ ../mass/bin/mass-linux-amd64 bundle new
2024/06/24 11:02:50 INFO Refreshing templates path=/home/michael/.massdriver
2024/06/24 11:02:51 INFO Templates are current, skipping download
2024/06/24 11:02:51 required environment variable not set: APIKey: missing required value: MASSDRIVER_API_KEY
```