### PR TITLE
Fuzzy match provisioner string

### DIFF
--- a/pkg/provisioners/types.go
+++ b/pkg/provisioners/types.go
@@ -1,5 +1,7 @@
 package provisioners
 
+import "strings"
+
 type Provisioner interface {
 	ExportMassdriverInputs(stepPath string, variables map[string]any) error
 	ReadProvisionerInputs(stepPath string) (map[string]any, error)
@@ -7,16 +9,14 @@ type Provisioner interface {
 }
 
 func NewProvisioner(provisionerType string) Provisioner {
-	switch provisionerType {
-	case "opentofu", "terraform":
+	if strings.Contains(provisionerType, "opentofu") || strings.Contains(provisionerType, "terraform") {
 		return new(OpentofuProvisioner)
-	case "helm":
+	} else if strings.Contains(provisionerType, "helm") {
 		return new(HelmProvisioner)
-	case "bicep":
+	} else if strings.Contains(provisionerType, "bicep") {
 		return new(BicepProvisioner)
-	default:
-		return new(NoopProvisioner)
 	}
+	return new(NoopProvisioner)
 }
 
 type NoopProvisioner struct{}

--- a/pkg/provisioners/types_test.go
+++ b/pkg/provisioners/types_test.go
@@ -1,0 +1,32 @@
+package provisioners_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/massdriver-cloud/mass/pkg/provisioners"
+)
+
+func TestNewProvisioner(t *testing.T) {
+	tests := []struct {
+		provisionerType string
+		expectedType    string
+	}{
+		{"opentofu", "*provisioners.OpentofuProvisioner"},
+		{"terraform", "*provisioners.OpentofuProvisioner"},
+		{"helm", "*provisioners.HelmProvisioner"},
+		{"bicep", "*provisioners.BicepProvisioner"},
+		{"blah", "*provisioners.NoopProvisioner"},
+		{"opentofu:1.10", "*provisioners.OpentofuProvisioner"},
+		{"012345678910.dkr.ecr.us-west-2.amazonaws.com/myorg/prov-opentofu", "*provisioners.OpentofuProvisioner"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.provisionerType, func(t *testing.T) {
+			provisioner := provisioners.NewProvisioner(tt.provisionerType)
+			if fmt.Sprintf("%T", provisioner) != tt.expectedType {
+				t.Errorf("expected %s, got %T", tt.expectedType, provisioner)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Removes the strict matching on "provisioner" when detecting which variable generation method to use. This breaks with custom (or versioned) provisioner images. This is a quick fix to support custom/versioned images. We'll need a more robust way in the future.