### PR TITLE
remove bundle from 'manifest' query in gql api

### DIFF
--- a/cmd/templates/environment.get.md.tmpl
+++ b/cmd/templates/environment.get.md.tmpl
@@ -8,7 +8,7 @@
 | Name | Bundle | Status |
 | ---- | ------ | ------ |
 {{- range .Packages}}
-| **{{.Manifest.Name}}** | {{.Manifest.Bundle.Name}} | {{.Status}} |
+| **{{.Manifest.Name}}** | {{.Bundle.Name}} | {{.Status}} |
 {{- end}}
 
 ## Cost

--- a/cmd/templates/package.get.md.tmpl
+++ b/cmd/templates/package.get.md.tmpl
@@ -1,6 +1,6 @@
 # Package: {{.NamePrefix}}
 
-**Bundle:** {{.Manifest.Bundle.Name}}
+**Bundle:** {{.Bundle.Name}}
 
 **Environment:** {{.Environment.Slug}}
 

--- a/pkg/api/environment_test.go
+++ b/pkg/api/environment_test.go
@@ -47,6 +47,10 @@ func TestGetEnvironment(t *testing.T) {
 						},
 					},
 				},
+				Bundle: &api.Bundle{
+					ID:   "bundle-uuid1",
+					Name: "test-bundle",
+				},
 				Status: string(api.PackageStatusProvisioned),
 				Manifest: &api.Manifest{
 					ID:          "manifest-uuid1",
@@ -54,13 +58,6 @@ func TestGetEnvironment(t *testing.T) {
 					Slug:        "manifest",
 					Suffix:      "0000",
 					Description: "This is a test manifest",
-					Bundle: &api.Bundle{
-						ID:   "bundle-uuid1",
-						Name: "Test Bundle",
-						Spec: map[string]any{
-							"key1": "value1",
-						},
-					},
 				},
 			},
 		},
@@ -108,6 +105,10 @@ func TestGetEnvironment(t *testing.T) {
 								},
 							},
 						},
+						"bundle": map[string]any{
+							"id":   "bundle-uuid1",
+							"name": "test-bundle",
+						},
 						"status": "PROVISIONED",
 						"manifest": map[string]any{
 							"id":          "manifest-uuid1",
@@ -115,14 +116,6 @@ func TestGetEnvironment(t *testing.T) {
 							"slug":        "manifest",
 							"suffix":      "0000",
 							"description": "This is a test manifest",
-							"bundle": map[string]any{
-								"id":      "bundle-uuid1",
-								"name":    "Test Bundle",
-								"version": "1.0.0",
-								"spec": map[string]any{
-									"key1": "value1",
-								},
-							},
 						},
 					},
 				},

--- a/pkg/api/genqlient.graphql
+++ b/pkg/api/genqlient.graphql
@@ -140,6 +140,12 @@ query getEnvironmentById($organizationId: ID!, $id: ID!) {
           field
         }
       }
+      bundle {
+        id
+        name
+        spec
+        specVersion
+      }
       status
       manifest {
         id
@@ -147,12 +153,6 @@ query getEnvironmentById($organizationId: ID!, $id: ID!) {
         slug
         suffix
         description
-        bundle {
-          id
-          name
-          spec
-          specVersion
-        }
       }
     }
     project {
@@ -198,18 +198,18 @@ query getEnvironmentsByProject($organizationId: ID!, $projectId: ID!) {
             field
           }
         }
+        bundle {
+          id
+          name
+          spec
+          specVersion
+        }
         manifest {
           id
           name
           slug
           suffix
           description
-          bundle {
-            id
-            name
-            spec
-            specVersion
-          }
         }
       }
       project {
@@ -254,18 +254,18 @@ query getPackage($organizationId: ID!, $id: ID!) {
         field
       }
     }
+    bundle {
+      id
+      name
+      spec
+      specVersion
+    }
     manifest {
       id
       name
       slug
       suffix
       description
-      bundle {
-        id
-        name
-        spec
-        specVersion
-      }
     }
     environment {
       id

--- a/pkg/api/manifest.go
+++ b/pkg/api/manifest.go
@@ -1,10 +1,9 @@
 package api
 
 type Manifest struct {
-	ID          string  `json:"id"`
-	Slug        string  `json:"slug"`
-	Name        string  `json:"name"`
-	Suffix      string  `json:"suffix"`
-	Description string  `json:"description"`
-	Bundle      *Bundle `json:"bundle,omitempty" mapstructure:"bundle,omitempty"`
+	ID          string `json:"id"`
+	Slug        string `json:"slug"`
+	Name        string `json:"name"`
+	Suffix      string `json:"suffix"`
+	Description string `json:"description"`
 }

--- a/pkg/api/package.go
+++ b/pkg/api/package.go
@@ -15,6 +15,7 @@ type Package struct {
 	Status           string            `json:"status"`
 	Artifacts        []Artifact        `json:"artifacts,omitempty"`
 	RemoteReferences []RemoteReference `json:"remoteReferences,omitempty"`
+	Bundle           *Bundle           `json:"bundle,omitempty" mapstructure:"bundle,omitempty"`
 	Params           map[string]any    `json:"params"`
 	Manifest         *Manifest         `json:"manifest" mapstructure:"manifest,omitempty"`
 	Environment      *Environment      `json:"environment,omitempty" mapstructure:"environment,omitempty"`

--- a/pkg/api/package_test.go
+++ b/pkg/api/package_test.go
@@ -17,6 +17,9 @@ func TestGetPackageByName(t *testing.T) {
 		"data": map[string]any{
 			"package": map[string]any{
 				"namePrefix": fmt.Sprintf("%s-0000", pkgName),
+				"bundle": map[string]any{
+					"id": "bundle-id",
+				},
 				"manifest": map[string]any{
 					"id": "manifest-id",
 				},
@@ -38,9 +41,11 @@ func TestGetPackageByName(t *testing.T) {
 
 	want := &api.Package{
 		NamePrefix: "ecomm-prod-cache-0000",
+		Bundle: &api.Bundle{
+			ID: "bundle-id",
+		},
 		Manifest: &api.Manifest{
-			ID:     "manifest-id",
-			Bundle: &api.Bundle{},
+			ID: "manifest-id",
 		},
 		Environment: &api.Environment{
 			ID:      "target-id",

--- a/pkg/api/repo.go
+++ b/pkg/api/repo.go
@@ -1,0 +1,5 @@
+package api
+
+type Repo struct {
+	Name string `json:"name"`
+}

--- a/pkg/api/schema.graphql
+++ b/pkg/api/schema.graphql
@@ -5,6 +5,20 @@ schema {
   subscription: RootSubscriptionType
 }
 
+type BundlePackagesPage {
+  "List of package summaries"
+  items: [BundlePackageSummary]!
+
+  "Cursor for the next page of results"
+  cursor: String
+}
+
+"OCI blob content"
+type OciBlobContent {
+  "The blob content"
+  content: String!
+}
+
 enum AlarmStatus {
   "The metric is within normal operating parameters and below the alarm threshold."
   OK
@@ -55,16 +69,44 @@ type RootSubscriptionType {
     id: ID!
   ): DeploymentLogStreamLog
   deploymentProgress(organizationId: ID!, packageId: ID!): ProvisioningLifecycleEvents
-  nodeDeleted(organizationId: ID!, projectId: ID!): DeletedNode
-  nodeCreated(organizationId: ID!, projectId: ID!): Node
-  nodeUpdated(organizationId: ID!, projectId: ID!): Node
-  linkCreated(organizationId: ID!, projectId: ID!): Link
-  linkDeleted(organizationId: ID!, projectId: ID!): Link
+  nodeDeleted(
+    organizationId: ID!
+
+    "Project ID"
+    projectId: ID!
+  ): DeletedNode
+  nodeCreated(
+    organizationId: ID!
+
+    "Project ID"
+    projectId: ID!
+  ): Node
+  nodeUpdated(
+    organizationId: ID!
+
+    "Project ID"
+    projectId: ID!
+  ): Node
+  linkCreated(
+    organizationId: ID!
+
+    "Environment ID"
+    environmentId: ID!
+  ): Link
+  linkDeleted(
+    organizationId: ID!
+
+    "Environment ID"
+    environmentId: ID!
+  ): Link
+  linkUpdated(
+    organizationId: ID!
+
+    "Environment ID"
+    environmentId: ID!
+  ): Link
   nodeContextCreated(organizationId: ID!, environmentId: ID!): NodeContext
   nodeContextDeleted(organizationId: ID!, environmentId: ID!): NodeContext
-  linkContextUpdated(organizationId: ID!, environmentId: ID!): LinkContext
-  linkContextCreated(organizationId: ID!, environmentId: ID!): LinkContext
-  linkContextDeleted(organizationId: ID!, environmentId: ID!): LinkContext
   packageAlarms(organizationId: ID!, packageId: ID!): Alarm
 }
 
@@ -117,48 +159,6 @@ type PackageAlarmState {
   occurredAt: DateTime!
 }
 
-"A manifest node in the diagram"
-type ManifestResource {
-  "ID of the underlying manifest"
-  id: ID!
-
-  "Manifest name"
-  name: String
-
-  package: Package @deprecated
-
-  "The manifest"
-  manifest: Manifest
-
-  artifacts: [Artifact] @deprecated
-
-  deployments: [Deployment] @deprecated
-}
-
-"An artifact node in the diagram"
-type ArtifactResource {
-  "Artifact name"
-  name: String
-
-  "Artifact type"
-  type: String
-
-  "Unique identifier"
-  id: ID
-
-  "ID of the underlying artifact"
-  artifactId: ID
-
-  "Origin of the artifact"
-  origin: String
-
-  "ID of the source target"
-  sourceTargetId: ID
-
-  "ID of the source project"
-  sourceProjectId: ID
-}
-
 "Service account with generated secret."
 type ServiceAccountWithSecret {
   id: ID!
@@ -198,21 +198,6 @@ type SecretField {
   valueMetadata: SecretMetadata
 }
 
-"SSO configuration parameters"
-input ConfigureSsoInput {
-  "The OAuth2 client ID from your identity provider"
-  clientId: String!
-
-  "The OAuth2 client secret from your identity provider"
-  clientSecret: String!
-
-  "The authorization endpoint URL from your identity provider"
-  authorizeUrl: String!
-
-  "The token endpoint URL from your identity provider"
-  tokenUrl: String!
-}
-
 type RecentDeployment {
   id: ID!
   packageSlug: String!
@@ -226,6 +211,26 @@ type RecentDeployment {
   createdAt: DateTime!
   status: String!
   action: String!
+}
+
+enum BundlePackagesSortField {
+  "Sort by bundle version"
+  VERSION
+
+  "Sort by last updated timestamp"
+  UPDATED_AT
+
+  "Sort by package slug"
+  SLUG
+
+  "Sort by package status"
+  STATUS
+
+  "Sort by last month's cost"
+  LAST_MONTHS_COST
+
+  "Sort by project name"
+  PROJECT_NAME
 }
 
 input ArtifactsInput {
@@ -361,9 +366,7 @@ type Project {
 
   deletable: ProjectDeletionLifecycle!
 
-  defaultParams: JSON
-
-  diagram: Diagram
+  defaultParams: JSON @deprecated(reason: "Default params are being deprecated for preview environments in favor of inherit\/override PEs from specific environments. This field will be removed in a future release.")
 
   "Cloud provider costs for this project"
   cost: Cost
@@ -404,6 +407,36 @@ input Credential {
   artifactId: ID!
 }
 
+"Optimized summary view of a package for list displays"
+type BundlePackageSummary {
+  "Package ID"
+  id: ID!
+
+  "Package slug (e.g., 'joesand-dev-myvpc')"
+  slug: String!
+
+  "Package name"
+  name: String!
+
+  "Package status"
+  status: PackageStatus!
+
+  "Project name (denormalized)"
+  projectName: String!
+
+  "Environment name (denormalized)"
+  environmentName: String!
+
+  "Package cost for the last month"
+  lastMonthsCost: Float
+
+  "Bundle version deployed"
+  version: String!
+
+  "Last update timestamp"
+  updatedAt: DateTime!
+}
+
 "A service account represents a non-human account used for automated access"
 type ServiceAccount {
   id: ID!
@@ -418,6 +451,10 @@ input ContainerRepositoryInput {
   imageName: String!
 }
 
+type ServerFeatures {
+  orgCreationEnabled: Boolean!
+}
+
 type DeploymentStatistic {
   bundleId: ID!
   bundleName: String!
@@ -427,10 +464,11 @@ type DeploymentStatistic {
 }
 
 type Server {
+  appUrl: String!
   version: String!
   mode: ServerMode!
-  appUrl: String!
-  ssoProviders: [PublicSsoProvider]
+  ssoProviders: [SsoProvider]
+  features: ServerFeatures! @deprecated(reason: "")
 }
 
 "Error information for bundle deletion"
@@ -479,27 +517,6 @@ type ValidationOption {
   value: String!
 }
 
-"A package node in the diagram"
-type PackageResource {
-  "ID of the underlying package"
-  id: ID!
-
-  "Manifest name for the current package name"
-  name: String
-
-  "The package"
-  package: Package
-
-  "The manifest"
-  manifest: Manifest
-
-  "Artifacts associated with this package"
-  artifacts: [Artifact]
-
-  "Deployments associated with this package"
-  deployments: [Deployment]
-}
-
 type AuditLogResponse {
   events: [AuditLog]!
   cursor: String
@@ -514,17 +531,6 @@ type ServiceAccountWithSecretPayload {
 
   "The object created\/updated\/deleted by the mutation. May be null if mutation failed."
   result: ServiceAccountWithSecret
-}
-
-type SsoConfigPayload {
-  "Indicates if the mutation completed successfully or not."
-  successful: Boolean!
-
-  "A list of failed validations. May be blank or null if mutation succeeded."
-  messages: [ValidationMessage]
-
-  "The object created\/updated\/deleted by the mutation. May be null if mutation failed."
-  result: SsoConfig
 }
 
 type InvitationPayload {
@@ -549,6 +555,14 @@ type EnvironmentConnectionPayload {
   result: EnvironmentConnection
 }
 
+input BundlePackagesSort {
+  "Field to sort by"
+  field: BundlePackagesSortField!
+
+  "Sort order"
+  order: SortOrder!
+}
+
 type ArtifactPayload {
   "Indicates if the mutation completed successfully or not."
   successful: Boolean!
@@ -560,42 +574,9 @@ type ArtifactPayload {
   result: Artifact
 }
 
-type PublicSsoProvider {
-  name: String!
-
-  "OAuth Login Flow URL"
-  loginUrl: String!
-}
-
 type ContainerRepositoryAuth {
   repoUri: String!
   token: String!
-}
-
-type SsoConfig {
-  "The unique identifier for the SSO configuration"
-  id: ID!
-
-  "The OAuth2 client ID from your identity provider"
-  clientId: String!
-
-  "The callback URL where users will be redirected after authentication"
-  redirectUri: String!
-
-  "OAuth Login Flow URL"
-  loginUrl: String!
-
-  "The authorization endpoint URL from your identity provider"
-  authorizeUrl: String!
-
-  "The token endpoint URL from your identity provider"
-  tokenUrl: String!
-
-  "When the SSO configuration was created"
-  createdAt: DateTime!
-
-  "When the SSO configuration was last updated"
-  updatedAt: DateTime!
 }
 
 "Lifecycle information for package deletion"
@@ -627,13 +608,36 @@ type Package {
   "When the package was last updated"
   updatedAt: DateTime!
 
-  "The version constraint for this package. Can be an exact version (1.2.3), release channel (~1.2), or automation rule (latest, release candidate)."
-  version: String!
+  bundle: Bundle!
 
-  currentDeployedVersion: String!
+  """
+  The version constraint for this package. This determines which bundle release version the package should use.
+  Supports semver constraints (~1.2, ~1), exact versions (1.2.3), and release channels (latest).
+  See `VersionConstraint` type documentation for supported formats and examples.
+  """
+  version: VersionConstraint!
 
-  "The resolved semantic version that would be deployed right now based on the version constraint. Always a specific x.y.z version."
-  nextDeployableVersion: String!
+  """
+  The actual semantic version of the bundle release currently configured for this package.
+  This is the resolved version based on the `version` constraint and will be used for the next deployment.
+  Example: if `version` is "~1.2", `currentVersion` might be "1.2.5".
+  """
+  currentVersion: String!
+
+  """
+  The semantic version that was last executed.
+  This reflects what has been provisioned to infrastructure, which may differ from `currentVersion`
+  if the package hasn't been deployed since the version was changed. Returns nil if never deployed.
+  """
+  deployedVersion: String
+
+  """
+  The newest version available for upgrade based on the package's `version` constraint.
+  Returns nil if no upgrade is available or if already on the latest matching version.
+  For strict semver constraints (1.2.3), checks for patch-level upgrades (~1.2).
+  For release channels (~1.2, ~1, latest), checks for the newest matching version.
+  """
+  availableUpgrade: String
 
   "Cloud alarms configured through IaC for this package"
   alarms: [Alarm]
@@ -668,12 +672,12 @@ type Package {
   cost: Cost
 }
 
-"A node in the diagram"
+"An infrastructure component in the diagram"
 type Node {
   "ID of the manifest"
   manifestId: ID!
 
-  "Name of the node"
+  "Manifest Name"
   name: String!
 
   "Type of the node (organization\/bundle)"
@@ -684,12 +688,6 @@ type Node {
 
   "Y coordinate position in the diagram"
   positionY: Int!
-
-  "Handles for artifact connections"
-  artifactHandles: [Handle]!
-
-  "Handles for resource connections"
-  connectionHandles: [Handle]!
 }
 
 "Lifecycle information for bundle deletion"
@@ -707,28 +705,28 @@ response as an ISO8601 formatted string, without a time component.
 """
 scalar Date
 
-"Context information for a node"
+"Contextual information about a node in the diagram"
 type NodeContext {
   "ID of the manifest"
   manifestId: ID!
 
   "ID of the package"
-  packageId: ID!
+  packageId: ID
 
   "Slug of the package"
-  packageSlug: String!
-}
+  packageSlug: String
 
-"Context information for a link"
-type LinkContext {
-  "ID of the link"
-  id: ID!
+  "Manifest Name"
+  name: String!
 
-  "ID of the environment"
-  environmentId: ID!
+  "Type of the node (organization\/bundle)"
+  type: String!
 
-  "Whether this is a connection"
-  isConnection: Boolean
+  "Handles for artifact connections"
+  artifactHandles: [Handle]!
+
+  "Handles for resource connections"
+  connectionHandles: [Handle]!
 }
 
 "Cost information for a resource"
@@ -822,11 +820,11 @@ type RootQueryType {
 
   compareDeployments(organizationId: ID!, fromDeploymentId: ID!, toDeploymentId: ID!): Changeset
 
-  "Marketplace Blueprints"
+  "Marketplace Templates"
   templates(
     "Organization ID"
     organizationId: ID!
-  ): [Bundle]
+  ): [Template]
 
   "List all bundles"
   bundles(
@@ -839,8 +837,11 @@ type RootQueryType {
     "Organization ID"
     organizationId: ID!
 
-    "Bundle ID"
+    "Bundle UUID or Name"
     id: ID!
+
+    "Specifies which bundle release to return. Can be an exact version (e.g., '1.2.3'), a tilde constraint for semantic versioning ranges (e.g., '~1.2' for 1.2.x, '~1' for 1.x.x), or 'latest' for the newest stable release."
+    version: VersionConstraint
   ): Bundle
 
   "Get a specific template"
@@ -852,14 +853,26 @@ type RootQueryType {
     id: ID!
   ): Bundle
 
-  "Get bundle source code"
-  bundleSourceCode(
+  "Get packages deployed from this bundle with filtering and pagination"
+  bundlePackages(
     "Organization ID"
     organizationId: ID!
 
-    "Bundle ID"
+    "Bundle ID or Name"
     id: ID!
-  ): BundleSource
+
+    "Filter criteria"
+    filter: BundlePackagesFilter
+
+    "Sort criteria"
+    sort: BundlePackagesSort
+
+    "Maximum number of items to return (default: 10, max: 100)"
+    limit: Int
+
+    "Pagination cursor"
+    cursor: String
+  ): BundlePackagesPage
 
   containerRepository(organizationId: ID!, artifactId: ID!, input: ContainerRepositoryInput!): ContainerRepositoryAuth @deprecated(reason: "This function will be removed in the near future.")
 
@@ -873,11 +886,8 @@ type RootQueryType {
     "The field to find dependencies for."
     fieldName: String!
 
-    "Optional. If specified, recommendations are tailored to the environment, prioritizing bundles and manifests of the same cloud as the credentials attached to the environment."
-    targetId: ID @deprecated(reason: "Use environmentId")
-
-    "Optional. If specified, recommendations are tailored to the environment, prioritizing bundles and manifests of the same cloud as the credentials attached to the environment."
-    environmentId: ID
+    "If specified, recommendations are tailored to the environment, prioritizing bundles and manifests in the current environment."
+    environmentId: ID!
   ): DependencyRecommendations
 
   deployment(
@@ -914,11 +924,9 @@ type RootQueryType {
     projectId: ID!
   ): [Node]
 
-  links(organizationId: ID!, projectId: ID!): [Link]
+  links(organizationId: ID!, environmentId: ID!): [Link]
 
   nodeContexts(organizationId: ID!, environmentId: ID!): [NodeContext]
-
-  linkContexts(organizationId: ID!, environmentId: ID!): [LinkContext]
 
   environment(
     organizationId: ID!
@@ -945,6 +953,42 @@ type RootQueryType {
     "Manifest ID or slug"
     id: ID!
   ): Manifest
+
+  "Get an OCI repository"
+  ociRepo(
+    "Organization ID"
+    organizationId: ID!
+
+    "Bundle ID or Name"
+    id: ID!
+  ): OciRepo
+
+  "Get an OCI manifest by tag"
+  ociManifest(
+    "Organization ID"
+    organizationId: ID!
+
+    "OCI Repo name"
+    id: ID!
+
+    "OCI tag (e.g., '0.0.0', '1.1.3')"
+    tag: String!
+  ): OciManifest
+
+  "Get an OCI blob content by digest"
+  ociBlob(
+    "Organization ID"
+    organizationId: ID!
+
+    "Bundle ID or Name"
+    id: ID!
+
+    "OCI tag (for authorization context)"
+    tag: String!
+
+    "Blob digest (e.g., 'sha256:...')"
+    digest: String!
+  ): OciBlobContent
 
   "Gets the organization the user has selected to act on behalf of"
   organization(organizationId: ID!): Organization!
@@ -990,6 +1034,18 @@ be converted to UTC if there is an offset.
 """
 scalar DateTime
 
+"A JSON document describing the structure of an image or artifact, including its layers and configuration"
+type OciManifest {
+  "The media type of this manifest (e.g., application\/vnd.oci.image.manifest.v1+json)"
+  mediaType: String!
+
+  "Content-addressable identifier of this manifest (e.g., sha256:abcd...)"
+  digest: String!
+
+  "The blobs (layers and config) that make up this image or artifact"
+  blobs: [OciBlob]
+}
+
 "An instance of a bundle in a project's architecture, providing context for how the bundle is used"
 type Manifest {
   id: ID!
@@ -1003,7 +1059,6 @@ type Manifest {
   updatedAt: DateTime!
   bundle: Bundle!
   packages: [Package]
-  linkableFields: [LinkableField]
 }
 
 enum OrganizationBillingStatus {
@@ -1064,8 +1119,6 @@ type ArtifactDefinition {
   icon: String
 
   label: String!
-
-  type: String @deprecated(reason: "use `name` field")
 
   exportFormats: [ArtifactDefinitionExportFormat]
 }
@@ -1199,6 +1252,15 @@ enum AuditLogActor {
 
   "Deployment"
   DEPLOYMENT
+}
+
+"OCI annotation - arbitrary key-value pair for storing custom metadata"
+type OciAnnotation {
+  "The annotation key (e.g., 'org.opencontainers.artifact.title')"
+  name: String!
+
+  "The annotation value"
+  value: String!
 }
 
 type OrganizationBilling {
@@ -1423,9 +1485,6 @@ type Environment {
 
   updatedAt: DateTime
 
-  "Environment's diagram links and resources"
-  diagram: Diagram
-
   "Manifests for this environment's package"
   manifests: [Manifest]
 
@@ -1467,10 +1526,21 @@ input RemoteReferenceParams {
   field: String
 }
 
+enum SortOrder {
+  "Ascending order"
+  ASC
+
+  "Descending order"
+  DESC
+}
+
 "A connection between two nodes in the diagram"
 type Link {
   "Unique identifier for the link"
   id: ID!
+
+  "ID of the environment"
+  environmentId: ID
 
   "Source field name"
   srcField: String!
@@ -1479,7 +1549,7 @@ type Link {
   destField: String!
 
   "Whether this link represents a connection"
-  isConnection: Boolean
+  isConnection: Boolean!
 
   "When the link was created"
   createdAt: DateTime!
@@ -1512,15 +1582,6 @@ type DeploymentLogStreamLog {
   metadata: DeploymentLogStreamLogMetadata!
 }
 
-"Source code information for a bundle"
-type BundleSource {
-  "The bundle"
-  bundle: Bundle!
-
-  "Source code content"
-  source: String!
-}
-
 type ServiceAccountPayload {
   "Indicates if the mutation completed successfully or not."
   successful: Boolean!
@@ -1549,6 +1610,13 @@ enum ArtifactDefinitionAccess {
   PRIVATE
 }
 
+type SsoProvider {
+  name: String!
+
+  "OAuth Login Flow URL"
+  loginUrl: String!
+}
+
 "A service account group membership"
 type ServiceAccountMember {
   id: ID!
@@ -1559,6 +1627,21 @@ type ServiceAccountMember {
 input AuditLogFilter {
   id: ID
   type: AuditLogFilterOption
+}
+
+"A namespace for storing related container images and artifacts"
+type OciRepo {
+  "The repository name within the registry"
+  name: String!
+
+  "Timestamp when the repository was created"
+  createdAt: DateTime!
+
+  "Distribution channels for artifact releases"
+  releaseChannels: [OciReleaseChannel]
+
+  "Human-readable references to manifests in this repository"
+  tags: [OciTag]
 }
 
 type OrganizationBillingPlan {
@@ -1581,6 +1664,15 @@ type OrganizationBillingPlan {
   frequency: OrganizationBillingFrequency!
 }
 
+"A release channel that resolves to a specific tag"
+type OciReleaseChannel {
+  "The channel name (e.g., 'latest', '1.x', '0.x')"
+  name: String!
+
+  "The tag this channel resolves to (e.g., '1.0.0')"
+  tag: String!
+}
+
 type SecretMetadataPayload {
   "Indicates if the mutation completed successfully or not."
   successful: Boolean!
@@ -1590,12 +1682,6 @@ type SecretMetadataPayload {
 
   "The object created\/updated\/deleted by the mutation. May be null if mutation failed."
   result: SecretMetadata
-}
-
-"Field that an artifact can be linked to on this manifest."
-type LinkableField {
-  name: String!
-  artifactDefinitions: [ArtifactDefinition]!
 }
 
 "Supported download formats"
@@ -1673,9 +1759,6 @@ type Handle {
   "Type of the handle"
   type: String!
 
-  "Whether this handle can be linked"
-  isLinkable: Boolean! @deprecated(reason: "see connectionOrientation")
-
   "Whether this handle is required"
   required: Boolean!
 
@@ -1683,7 +1766,7 @@ type Handle {
   connectionOrientation: ArtifactDefinitionUiConnectionOrientation!
 }
 
-"A reusable infrastructure component that packages IaC modules, policies, runbooks, and cloud dependencies into a deliverable software component"
+"A specific version of a bundle"
 type Bundle {
   "Unique identifier"
   id: ID!
@@ -1697,19 +1780,14 @@ type Bundle {
   "Raw massdriver.yaml spec"
   spec: JSON!
 
+  "Semantic version of this bundle release"
+  version: String!
+
   "Version of the bundle specification"
   specVersion: String
 
-  "Application or bundle"
-  type: String!
-
-  "Private bundle or public template"
-  access: String!
-
   "Description of the bundle"
   description: String
-
-  ref: String @deprecated(reason: "See sourceUrl")
 
   "URL to the source code repository"
   sourceUrl: String
@@ -1735,17 +1813,8 @@ type Bundle {
   "When the bundle was last updated"
   updatedAt: DateTime!
 
-  "List of available versions for this bundle"
-  versions: [String]
-
-  "Information about whether the bundle can be deleted"
+  "Information about whether the bundle repo can be deleted"
   deletable: BundleDeletionLifecycle!
-
-  "The full name of the bundle"
-  fqn: String! @deprecated(reason: "See ociImageReference")
-
-  "OCI Image Reference URL"
-  ociImageReference: String!
 }
 
 type AccountMembershipPayload {
@@ -1775,6 +1844,10 @@ type Deployment {
   status: String!
 
   action: String!
+
+  version: String!
+
+  release: Bundle!
 
   message: String
 
@@ -1964,7 +2037,7 @@ type RootMutationType {
 
   "Links two manifests"
   linkManifests(
-    organizationId: ID!, srcManifestId: ID!, srcManifestField: String!, destManifestId: ID!, destManifestField: String!
+    organizationId: ID!, environmentId: ID!, srcManifestId: ID!, srcManifestField: String!, destManifestId: ID!, destManifestField: String!
   ): LinkPayload
 
   unlinkManifests(organizationId: ID!, linkId: ID!): LinkPayload
@@ -2050,15 +2123,6 @@ type RootMutationType {
 
   "Create an organization"
   createOrganization(name: String!, slug: String!): OrganizationPayload
-
-  "Configure SSO for an organization"
-  configureSso(
-    "The ID of the organization to configure SSO for"
-    organizationId: ID!
-
-    "The SSO configuration parameters"
-    input: ConfigureSsoInput!
-  ): SsoConfigPayload
 
   """
   Reset a package to its initialized state. This is useful for:
@@ -2178,18 +2242,6 @@ type EnvironmentConnection {
   updatedAt: DateTime
 }
 
-"A diagram representing relationships between resources"
-type Diagram {
-  "Unique identifier for the diagram"
-  id: ID!
-
-  "Links between nodes in the diagram"
-  links: [Link]
-
-  "Resources (nodes) in the diagram"
-  resources: [Resource]
-}
-
 enum OrganizationBillingFrequency {
   "Monthly billing frequency."
   MONTHLY
@@ -2197,9 +2249,6 @@ enum OrganizationBillingFrequency {
   "Annual billing frequency."
   ANNUALLY
 }
-
-"Artifact and manifest nodes"
-union Resource = ManifestResource | PackageResource | ArtifactResource
 
 input UnsetSecretValueInput {
   "Name defined in applications massdriver.yaml file."
@@ -2300,10 +2349,49 @@ type Connection {
   updatedAt: DateTime
 }
 
+"A human-readable reference name that points to a specific OCI manifest"
+type OciTag {
+  "The media type of the referenced manifest (e.g., application\/vnd.oci.image.manifest.v1+json)"
+  mediaType: String!
+
+  "Timestamp when this tag was created or last updated"
+  createdAt: DateTime!
+
+  "The tag name\/label (e.g., 'latest', 'v1.0.0')"
+  tag: String!
+
+  "Release notes for this tagged version"
+  releaseNotes: String
+
+  "Content-addressable identifier of the manifest (e.g., sha256:abcd...)"
+  digest: String!
+}
+
 "Information about a deleted node"
 type DeletedNode {
   "ID of the deleted manifest"
   manifestId: ID!
+}
+
+"A template bundle"
+type Template {
+  "Unique identifier"
+  id: ID!
+
+  "Name of the template"
+  name: String!
+
+  "Description of the bundle"
+  description: String
+
+  "The operator guide for the bundle in markdown."
+  operatorGuide: Markdown
+
+  "JSON schema for bundle parameters"
+  paramsSchema: JSON!
+
+  "URL to the source code repository"
+  sourceUrl: String
 }
 
 input SetSecretValueInput {
@@ -2319,6 +2407,9 @@ input GroupInput {
   name: String!
   description: String
 }
+
+"Version constraint for bundle releases. Supports exact versions (1.2.3), tilde constraints (~1.2, ~1), automation rules (latest, release-candidate), and release channels. Examples: '1.2.3' (exact), '~1.2' (latest patch in 1.2.x), '~1' (latest minor in 1.x.x), 'latest' (newest stable), 'release-candidate' (newest RC)"
+scalar VersionConstraint
 
 "Statistics and metrics including bundle usage, deployment history, and active alarms."
 type DashboardStatistics {
@@ -2336,4 +2427,24 @@ type DashboardStatistics {
 
   "Shows the 20 most recent infrastructure changes, ordered by when the deployment was created. This panel provides visibility into the latest infrastructure modifications across your environments."
   recentInfrastructureDeployments: [RecentDeployment]
+}
+
+"Content-addressable storage for image layers, configurations, and other artifact data"
+type OciBlob {
+  "The media type of this blob (e.g., application\/vnd.oci.image.layer.v1.tar+gzip)"
+  mediaType: String!
+
+  "Content-addressable identifier of the blob content (e.g., sha256:abcd...)"
+  digest: String!
+
+  "Size of the blob in bytes"
+  size: Int!
+
+  "Optional key-value pairs providing additional metadata"
+  annotations: [OciAnnotation]
+}
+
+input BundlePackagesFilter {
+  "Filter by bundle version (exact match or release channel like 'latest', '~1', '1.0.0')"
+  version: String
 }

--- a/pkg/api/zz_generated.go
+++ b/pkg/api/zz_generated.go
@@ -1444,6 +1444,7 @@ type getEnvironmentByIdEnvironmentPackagesPackage struct {
 	Artifacts []getEnvironmentByIdEnvironmentPackagesPackageArtifactsArtifact `json:"artifacts"`
 	// Artifacts from a remote source like another project or a resource not managed by massdriver
 	RemoteReferences []getEnvironmentByIdEnvironmentPackagesPackageRemoteReferencesRemoteReference `json:"remoteReferences"`
+	Bundle           getEnvironmentByIdEnvironmentPackagesPackageBundle                            `json:"bundle"`
 	// Current status of the package
 	Status   PackageStatus                                        `json:"status"`
 	Manifest getEnvironmentByIdEnvironmentPackagesPackageManifest `json:"manifest"`
@@ -1463,6 +1464,11 @@ func (v *getEnvironmentByIdEnvironmentPackagesPackage) GetArtifacts() []getEnvir
 // GetRemoteReferences returns getEnvironmentByIdEnvironmentPackagesPackage.RemoteReferences, and is useful for accessing the field via an interface.
 func (v *getEnvironmentByIdEnvironmentPackagesPackage) GetRemoteReferences() []getEnvironmentByIdEnvironmentPackagesPackageRemoteReferencesRemoteReference {
 	return v.RemoteReferences
+}
+
+// GetBundle returns getEnvironmentByIdEnvironmentPackagesPackage.Bundle, and is useful for accessing the field via an interface.
+func (v *getEnvironmentByIdEnvironmentPackagesPackage) GetBundle() getEnvironmentByIdEnvironmentPackagesPackageBundle {
+	return v.Bundle
 }
 
 // GetStatus returns getEnvironmentByIdEnvironmentPackagesPackage.Status, and is useful for accessing the field via an interface.
@@ -1515,6 +1521,8 @@ type __premarshalgetEnvironmentByIdEnvironmentPackagesPackage struct {
 
 	RemoteReferences []getEnvironmentByIdEnvironmentPackagesPackageRemoteReferencesRemoteReference `json:"remoteReferences"`
 
+	Bundle getEnvironmentByIdEnvironmentPackagesPackageBundle `json:"bundle"`
+
 	Status PackageStatus `json:"status"`
 
 	Manifest getEnvironmentByIdEnvironmentPackagesPackageManifest `json:"manifest"`
@@ -1546,6 +1554,7 @@ func (v *getEnvironmentByIdEnvironmentPackagesPackage) __premarshalJSON() (*__pr
 	}
 	retval.Artifacts = v.Artifacts
 	retval.RemoteReferences = v.RemoteReferences
+	retval.Bundle = v.Bundle
 	retval.Status = v.Status
 	retval.Manifest = v.Manifest
 	return &retval, nil
@@ -1572,17 +1581,117 @@ func (v *getEnvironmentByIdEnvironmentPackagesPackageArtifactsArtifact) GetField
 	return v.Field
 }
 
+// getEnvironmentByIdEnvironmentPackagesPackageBundle includes the requested fields of the GraphQL type Bundle.
+// The GraphQL type's documentation follows.
+//
+// A specific version of a bundle
+type getEnvironmentByIdEnvironmentPackagesPackageBundle struct {
+	// Unique identifier
+	Id string `json:"id"`
+	// Name of the bundle
+	Name string `json:"name"`
+	// Raw massdriver.yaml spec
+	Spec map[string]any `json:"-"`
+	// Version of the bundle specification
+	SpecVersion string `json:"specVersion"`
+}
+
+// GetId returns getEnvironmentByIdEnvironmentPackagesPackageBundle.Id, and is useful for accessing the field via an interface.
+func (v *getEnvironmentByIdEnvironmentPackagesPackageBundle) GetId() string { return v.Id }
+
+// GetName returns getEnvironmentByIdEnvironmentPackagesPackageBundle.Name, and is useful for accessing the field via an interface.
+func (v *getEnvironmentByIdEnvironmentPackagesPackageBundle) GetName() string { return v.Name }
+
+// GetSpec returns getEnvironmentByIdEnvironmentPackagesPackageBundle.Spec, and is useful for accessing the field via an interface.
+func (v *getEnvironmentByIdEnvironmentPackagesPackageBundle) GetSpec() map[string]any { return v.Spec }
+
+// GetSpecVersion returns getEnvironmentByIdEnvironmentPackagesPackageBundle.SpecVersion, and is useful for accessing the field via an interface.
+func (v *getEnvironmentByIdEnvironmentPackagesPackageBundle) GetSpecVersion() string {
+	return v.SpecVersion
+}
+
+func (v *getEnvironmentByIdEnvironmentPackagesPackageBundle) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*getEnvironmentByIdEnvironmentPackagesPackageBundle
+		Spec json.RawMessage `json:"spec"`
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.getEnvironmentByIdEnvironmentPackagesPackageBundle = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	{
+		dst := &v.Spec
+		src := firstPass.Spec
+		if len(src) != 0 && string(src) != "null" {
+			err = scalars.UnmarshalJSON(
+				src, dst)
+			if err != nil {
+				return fmt.Errorf(
+					"unable to unmarshal getEnvironmentByIdEnvironmentPackagesPackageBundle.Spec: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+type __premarshalgetEnvironmentByIdEnvironmentPackagesPackageBundle struct {
+	Id string `json:"id"`
+
+	Name string `json:"name"`
+
+	Spec json.RawMessage `json:"spec"`
+
+	SpecVersion string `json:"specVersion"`
+}
+
+func (v *getEnvironmentByIdEnvironmentPackagesPackageBundle) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *getEnvironmentByIdEnvironmentPackagesPackageBundle) __premarshalJSON() (*__premarshalgetEnvironmentByIdEnvironmentPackagesPackageBundle, error) {
+	var retval __premarshalgetEnvironmentByIdEnvironmentPackagesPackageBundle
+
+	retval.Id = v.Id
+	retval.Name = v.Name
+	{
+
+		dst := &retval.Spec
+		src := v.Spec
+		var err error
+		*dst, err = scalars.MarshalJSON(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to marshal getEnvironmentByIdEnvironmentPackagesPackageBundle.Spec: %w", err)
+		}
+	}
+	retval.SpecVersion = v.SpecVersion
+	return &retval, nil
+}
+
 // getEnvironmentByIdEnvironmentPackagesPackageManifest includes the requested fields of the GraphQL type Manifest.
 // The GraphQL type's documentation follows.
 //
 // An instance of a bundle in a project's architecture, providing context for how the bundle is used
 type getEnvironmentByIdEnvironmentPackagesPackageManifest struct {
-	Id          string                                                     `json:"id"`
-	Name        string                                                     `json:"name"`
-	Slug        string                                                     `json:"slug"`
-	Suffix      string                                                     `json:"suffix"`
-	Description string                                                     `json:"description"`
-	Bundle      getEnvironmentByIdEnvironmentPackagesPackageManifestBundle `json:"bundle"`
+	Id          string `json:"id"`
+	Name        string `json:"name"`
+	Slug        string `json:"slug"`
+	Suffix      string `json:"suffix"`
+	Description string `json:"description"`
 }
 
 // GetId returns getEnvironmentByIdEnvironmentPackagesPackageManifest.Id, and is useful for accessing the field via an interface.
@@ -1600,114 +1709,6 @@ func (v *getEnvironmentByIdEnvironmentPackagesPackageManifest) GetSuffix() strin
 // GetDescription returns getEnvironmentByIdEnvironmentPackagesPackageManifest.Description, and is useful for accessing the field via an interface.
 func (v *getEnvironmentByIdEnvironmentPackagesPackageManifest) GetDescription() string {
 	return v.Description
-}
-
-// GetBundle returns getEnvironmentByIdEnvironmentPackagesPackageManifest.Bundle, and is useful for accessing the field via an interface.
-func (v *getEnvironmentByIdEnvironmentPackagesPackageManifest) GetBundle() getEnvironmentByIdEnvironmentPackagesPackageManifestBundle {
-	return v.Bundle
-}
-
-// getEnvironmentByIdEnvironmentPackagesPackageManifestBundle includes the requested fields of the GraphQL type Bundle.
-// The GraphQL type's documentation follows.
-//
-// A reusable infrastructure component that packages IaC modules, policies, runbooks, and cloud dependencies into a deliverable software component
-type getEnvironmentByIdEnvironmentPackagesPackageManifestBundle struct {
-	// Unique identifier
-	Id string `json:"id"`
-	// Name of the bundle
-	Name string `json:"name"`
-	// Raw massdriver.yaml spec
-	Spec map[string]any `json:"-"`
-	// Version of the bundle specification
-	SpecVersion string `json:"specVersion"`
-}
-
-// GetId returns getEnvironmentByIdEnvironmentPackagesPackageManifestBundle.Id, and is useful for accessing the field via an interface.
-func (v *getEnvironmentByIdEnvironmentPackagesPackageManifestBundle) GetId() string { return v.Id }
-
-// GetName returns getEnvironmentByIdEnvironmentPackagesPackageManifestBundle.Name, and is useful for accessing the field via an interface.
-func (v *getEnvironmentByIdEnvironmentPackagesPackageManifestBundle) GetName() string { return v.Name }
-
-// GetSpec returns getEnvironmentByIdEnvironmentPackagesPackageManifestBundle.Spec, and is useful for accessing the field via an interface.
-func (v *getEnvironmentByIdEnvironmentPackagesPackageManifestBundle) GetSpec() map[string]any {
-	return v.Spec
-}
-
-// GetSpecVersion returns getEnvironmentByIdEnvironmentPackagesPackageManifestBundle.SpecVersion, and is useful for accessing the field via an interface.
-func (v *getEnvironmentByIdEnvironmentPackagesPackageManifestBundle) GetSpecVersion() string {
-	return v.SpecVersion
-}
-
-func (v *getEnvironmentByIdEnvironmentPackagesPackageManifestBundle) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*getEnvironmentByIdEnvironmentPackagesPackageManifestBundle
-		Spec json.RawMessage `json:"spec"`
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.getEnvironmentByIdEnvironmentPackagesPackageManifestBundle = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	{
-		dst := &v.Spec
-		src := firstPass.Spec
-		if len(src) != 0 && string(src) != "null" {
-			err = scalars.UnmarshalJSON(
-				src, dst)
-			if err != nil {
-				return fmt.Errorf(
-					"unable to unmarshal getEnvironmentByIdEnvironmentPackagesPackageManifestBundle.Spec: %w", err)
-			}
-		}
-	}
-	return nil
-}
-
-type __premarshalgetEnvironmentByIdEnvironmentPackagesPackageManifestBundle struct {
-	Id string `json:"id"`
-
-	Name string `json:"name"`
-
-	Spec json.RawMessage `json:"spec"`
-
-	SpecVersion string `json:"specVersion"`
-}
-
-func (v *getEnvironmentByIdEnvironmentPackagesPackageManifestBundle) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *getEnvironmentByIdEnvironmentPackagesPackageManifestBundle) __premarshalJSON() (*__premarshalgetEnvironmentByIdEnvironmentPackagesPackageManifestBundle, error) {
-	var retval __premarshalgetEnvironmentByIdEnvironmentPackagesPackageManifestBundle
-
-	retval.Id = v.Id
-	retval.Name = v.Name
-	{
-
-		dst := &retval.Spec
-		src := v.Spec
-		var err error
-		*dst, err = scalars.MarshalJSON(
-			&src)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"unable to marshal getEnvironmentByIdEnvironmentPackagesPackageManifestBundle.Spec: %w", err)
-		}
-	}
-	retval.SpecVersion = v.SpecVersion
-	return &retval, nil
 }
 
 // getEnvironmentByIdEnvironmentPackagesPackageRemoteReferencesRemoteReference includes the requested fields of the GraphQL type RemoteReference.
@@ -1910,6 +1911,7 @@ type getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackage struc
 	Artifacts []getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageArtifactsArtifact `json:"artifacts"`
 	// Artifacts from a remote source like another project or a resource not managed by massdriver
 	RemoteReferences []getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageRemoteReferencesRemoteReference `json:"remoteReferences"`
+	Bundle           getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageBundle                            `json:"bundle"`
 	Manifest         getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageManifest                          `json:"manifest"`
 }
 
@@ -1941,6 +1943,11 @@ func (v *getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackage) 
 // GetRemoteReferences returns getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackage.RemoteReferences, and is useful for accessing the field via an interface.
 func (v *getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackage) GetRemoteReferences() []getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageRemoteReferencesRemoteReference {
 	return v.RemoteReferences
+}
+
+// GetBundle returns getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackage.Bundle, and is useful for accessing the field via an interface.
+func (v *getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackage) GetBundle() getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageBundle {
+	return v.Bundle
 }
 
 // GetManifest returns getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackage.Manifest, and is useful for accessing the field via an interface.
@@ -1994,6 +2001,8 @@ type __premarshalgetEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesP
 
 	RemoteReferences []getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageRemoteReferencesRemoteReference `json:"remoteReferences"`
 
+	Bundle getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageBundle `json:"bundle"`
+
 	Manifest getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageManifest `json:"manifest"`
 }
 
@@ -2025,6 +2034,7 @@ func (v *getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackage) 
 	}
 	retval.Artifacts = v.Artifacts
 	retval.RemoteReferences = v.RemoteReferences
+	retval.Bundle = v.Bundle
 	retval.Manifest = v.Manifest
 	return &retval, nil
 }
@@ -2052,17 +2062,123 @@ func (v *getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageAr
 	return v.Field
 }
 
+// getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageBundle includes the requested fields of the GraphQL type Bundle.
+// The GraphQL type's documentation follows.
+//
+// A specific version of a bundle
+type getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageBundle struct {
+	// Unique identifier
+	Id string `json:"id"`
+	// Name of the bundle
+	Name string `json:"name"`
+	// Raw massdriver.yaml spec
+	Spec map[string]any `json:"-"`
+	// Version of the bundle specification
+	SpecVersion string `json:"specVersion"`
+}
+
+// GetId returns getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageBundle.Id, and is useful for accessing the field via an interface.
+func (v *getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageBundle) GetId() string {
+	return v.Id
+}
+
+// GetName returns getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageBundle.Name, and is useful for accessing the field via an interface.
+func (v *getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageBundle) GetName() string {
+	return v.Name
+}
+
+// GetSpec returns getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageBundle.Spec, and is useful for accessing the field via an interface.
+func (v *getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageBundle) GetSpec() map[string]any {
+	return v.Spec
+}
+
+// GetSpecVersion returns getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageBundle.SpecVersion, and is useful for accessing the field via an interface.
+func (v *getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageBundle) GetSpecVersion() string {
+	return v.SpecVersion
+}
+
+func (v *getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageBundle) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageBundle
+		Spec json.RawMessage `json:"spec"`
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageBundle = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	{
+		dst := &v.Spec
+		src := firstPass.Spec
+		if len(src) != 0 && string(src) != "null" {
+			err = scalars.UnmarshalJSON(
+				src, dst)
+			if err != nil {
+				return fmt.Errorf(
+					"unable to unmarshal getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageBundle.Spec: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+type __premarshalgetEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageBundle struct {
+	Id string `json:"id"`
+
+	Name string `json:"name"`
+
+	Spec json.RawMessage `json:"spec"`
+
+	SpecVersion string `json:"specVersion"`
+}
+
+func (v *getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageBundle) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageBundle) __premarshalJSON() (*__premarshalgetEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageBundle, error) {
+	var retval __premarshalgetEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageBundle
+
+	retval.Id = v.Id
+	retval.Name = v.Name
+	{
+
+		dst := &retval.Spec
+		src := v.Spec
+		var err error
+		*dst, err = scalars.MarshalJSON(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to marshal getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageBundle.Spec: %w", err)
+		}
+	}
+	retval.SpecVersion = v.SpecVersion
+	return &retval, nil
+}
+
 // getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageManifest includes the requested fields of the GraphQL type Manifest.
 // The GraphQL type's documentation follows.
 //
 // An instance of a bundle in a project's architecture, providing context for how the bundle is used
 type getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageManifest struct {
-	Id          string                                                                              `json:"id"`
-	Name        string                                                                              `json:"name"`
-	Slug        string                                                                              `json:"slug"`
-	Suffix      string                                                                              `json:"suffix"`
-	Description string                                                                              `json:"description"`
-	Bundle      getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageManifestBundle `json:"bundle"`
+	Id          string `json:"id"`
+	Name        string `json:"name"`
+	Slug        string `json:"slug"`
+	Suffix      string `json:"suffix"`
+	Description string `json:"description"`
 }
 
 // GetId returns getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageManifest.Id, and is useful for accessing the field via an interface.
@@ -2088,118 +2204,6 @@ func (v *getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageMa
 // GetDescription returns getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageManifest.Description, and is useful for accessing the field via an interface.
 func (v *getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageManifest) GetDescription() string {
 	return v.Description
-}
-
-// GetBundle returns getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageManifest.Bundle, and is useful for accessing the field via an interface.
-func (v *getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageManifest) GetBundle() getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageManifestBundle {
-	return v.Bundle
-}
-
-// getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageManifestBundle includes the requested fields of the GraphQL type Bundle.
-// The GraphQL type's documentation follows.
-//
-// A reusable infrastructure component that packages IaC modules, policies, runbooks, and cloud dependencies into a deliverable software component
-type getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageManifestBundle struct {
-	// Unique identifier
-	Id string `json:"id"`
-	// Name of the bundle
-	Name string `json:"name"`
-	// Raw massdriver.yaml spec
-	Spec map[string]any `json:"-"`
-	// Version of the bundle specification
-	SpecVersion string `json:"specVersion"`
-}
-
-// GetId returns getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageManifestBundle.Id, and is useful for accessing the field via an interface.
-func (v *getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageManifestBundle) GetId() string {
-	return v.Id
-}
-
-// GetName returns getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageManifestBundle.Name, and is useful for accessing the field via an interface.
-func (v *getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageManifestBundle) GetName() string {
-	return v.Name
-}
-
-// GetSpec returns getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageManifestBundle.Spec, and is useful for accessing the field via an interface.
-func (v *getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageManifestBundle) GetSpec() map[string]any {
-	return v.Spec
-}
-
-// GetSpecVersion returns getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageManifestBundle.SpecVersion, and is useful for accessing the field via an interface.
-func (v *getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageManifestBundle) GetSpecVersion() string {
-	return v.SpecVersion
-}
-
-func (v *getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageManifestBundle) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageManifestBundle
-		Spec json.RawMessage `json:"spec"`
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageManifestBundle = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	{
-		dst := &v.Spec
-		src := firstPass.Spec
-		if len(src) != 0 && string(src) != "null" {
-			err = scalars.UnmarshalJSON(
-				src, dst)
-			if err != nil {
-				return fmt.Errorf(
-					"unable to unmarshal getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageManifestBundle.Spec: %w", err)
-			}
-		}
-	}
-	return nil
-}
-
-type __premarshalgetEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageManifestBundle struct {
-	Id string `json:"id"`
-
-	Name string `json:"name"`
-
-	Spec json.RawMessage `json:"spec"`
-
-	SpecVersion string `json:"specVersion"`
-}
-
-func (v *getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageManifestBundle) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageManifestBundle) __premarshalJSON() (*__premarshalgetEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageManifestBundle, error) {
-	var retval __premarshalgetEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageManifestBundle
-
-	retval.Id = v.Id
-	retval.Name = v.Name
-	{
-
-		dst := &retval.Spec
-		src := v.Spec
-		var err error
-		*dst, err = scalars.MarshalJSON(
-			&src)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"unable to marshal getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageManifestBundle.Spec: %w", err)
-		}
-	}
-	retval.SpecVersion = v.SpecVersion
-	return &retval, nil
 }
 
 // getEnvironmentsByProjectProjectEnvironmentsEnvironmentPackagesPackageRemoteReferencesRemoteReference includes the requested fields of the GraphQL type RemoteReference.
@@ -2276,6 +2280,7 @@ type getPackagePackage struct {
 	Artifacts []getPackagePackageArtifactsArtifact `json:"artifacts"`
 	// Artifacts from a remote source like another project or a resource not managed by massdriver
 	RemoteReferences []getPackagePackageRemoteReferencesRemoteReference `json:"remoteReferences"`
+	Bundle           getPackagePackageBundle                            `json:"bundle"`
 	Manifest         getPackagePackageManifest                          `json:"manifest"`
 	// The environment this package will be deployed to
 	Environment getPackagePackageEnvironment `json:"environment"`
@@ -2300,6 +2305,9 @@ func (v *getPackagePackage) GetArtifacts() []getPackagePackageArtifactsArtifact 
 func (v *getPackagePackage) GetRemoteReferences() []getPackagePackageRemoteReferencesRemoteReference {
 	return v.RemoteReferences
 }
+
+// GetBundle returns getPackagePackage.Bundle, and is useful for accessing the field via an interface.
+func (v *getPackagePackage) GetBundle() getPackagePackageBundle { return v.Bundle }
 
 // GetManifest returns getPackagePackage.Manifest, and is useful for accessing the field via an interface.
 func (v *getPackagePackage) GetManifest() getPackagePackageManifest { return v.Manifest }
@@ -2353,6 +2361,8 @@ type __premarshalgetPackagePackage struct {
 
 	RemoteReferences []getPackagePackageRemoteReferencesRemoteReference `json:"remoteReferences"`
 
+	Bundle getPackagePackageBundle `json:"bundle"`
+
 	Manifest getPackagePackageManifest `json:"manifest"`
 
 	Environment getPackagePackageEnvironment `json:"environment"`
@@ -2386,6 +2396,7 @@ func (v *getPackagePackage) __premarshalJSON() (*__premarshalgetPackagePackage, 
 	}
 	retval.Artifacts = v.Artifacts
 	retval.RemoteReferences = v.RemoteReferences
+	retval.Bundle = v.Bundle
 	retval.Manifest = v.Manifest
 	retval.Environment = v.Environment
 	return &retval, nil
@@ -2407,6 +2418,105 @@ func (v *getPackagePackageArtifactsArtifact) GetName() string { return v.Name }
 
 // GetField returns getPackagePackageArtifactsArtifact.Field, and is useful for accessing the field via an interface.
 func (v *getPackagePackageArtifactsArtifact) GetField() string { return v.Field }
+
+// getPackagePackageBundle includes the requested fields of the GraphQL type Bundle.
+// The GraphQL type's documentation follows.
+//
+// A specific version of a bundle
+type getPackagePackageBundle struct {
+	// Unique identifier
+	Id string `json:"id"`
+	// Name of the bundle
+	Name string `json:"name"`
+	// Raw massdriver.yaml spec
+	Spec map[string]any `json:"-"`
+	// Version of the bundle specification
+	SpecVersion string `json:"specVersion"`
+}
+
+// GetId returns getPackagePackageBundle.Id, and is useful for accessing the field via an interface.
+func (v *getPackagePackageBundle) GetId() string { return v.Id }
+
+// GetName returns getPackagePackageBundle.Name, and is useful for accessing the field via an interface.
+func (v *getPackagePackageBundle) GetName() string { return v.Name }
+
+// GetSpec returns getPackagePackageBundle.Spec, and is useful for accessing the field via an interface.
+func (v *getPackagePackageBundle) GetSpec() map[string]any { return v.Spec }
+
+// GetSpecVersion returns getPackagePackageBundle.SpecVersion, and is useful for accessing the field via an interface.
+func (v *getPackagePackageBundle) GetSpecVersion() string { return v.SpecVersion }
+
+func (v *getPackagePackageBundle) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*getPackagePackageBundle
+		Spec json.RawMessage `json:"spec"`
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.getPackagePackageBundle = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	{
+		dst := &v.Spec
+		src := firstPass.Spec
+		if len(src) != 0 && string(src) != "null" {
+			err = scalars.UnmarshalJSON(
+				src, dst)
+			if err != nil {
+				return fmt.Errorf(
+					"unable to unmarshal getPackagePackageBundle.Spec: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+type __premarshalgetPackagePackageBundle struct {
+	Id string `json:"id"`
+
+	Name string `json:"name"`
+
+	Spec json.RawMessage `json:"spec"`
+
+	SpecVersion string `json:"specVersion"`
+}
+
+func (v *getPackagePackageBundle) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *getPackagePackageBundle) __premarshalJSON() (*__premarshalgetPackagePackageBundle, error) {
+	var retval __premarshalgetPackagePackageBundle
+
+	retval.Id = v.Id
+	retval.Name = v.Name
+	{
+
+		dst := &retval.Spec
+		src := v.Spec
+		var err error
+		*dst, err = scalars.MarshalJSON(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to marshal getPackagePackageBundle.Spec: %w", err)
+		}
+	}
+	retval.SpecVersion = v.SpecVersion
+	return &retval, nil
+}
 
 // getPackagePackageEnvironment includes the requested fields of the GraphQL type Environment.
 type getPackagePackageEnvironment struct {
@@ -2443,12 +2553,11 @@ func (v *getPackagePackageEnvironmentProject) GetSlug() string { return v.Slug }
 //
 // An instance of a bundle in a project's architecture, providing context for how the bundle is used
 type getPackagePackageManifest struct {
-	Id          string                          `json:"id"`
-	Name        string                          `json:"name"`
-	Slug        string                          `json:"slug"`
-	Suffix      string                          `json:"suffix"`
-	Description string                          `json:"description"`
-	Bundle      getPackagePackageManifestBundle `json:"bundle"`
+	Id          string `json:"id"`
+	Name        string `json:"name"`
+	Slug        string `json:"slug"`
+	Suffix      string `json:"suffix"`
+	Description string `json:"description"`
 }
 
 // GetId returns getPackagePackageManifest.Id, and is useful for accessing the field via an interface.
@@ -2465,108 +2574,6 @@ func (v *getPackagePackageManifest) GetSuffix() string { return v.Suffix }
 
 // GetDescription returns getPackagePackageManifest.Description, and is useful for accessing the field via an interface.
 func (v *getPackagePackageManifest) GetDescription() string { return v.Description }
-
-// GetBundle returns getPackagePackageManifest.Bundle, and is useful for accessing the field via an interface.
-func (v *getPackagePackageManifest) GetBundle() getPackagePackageManifestBundle { return v.Bundle }
-
-// getPackagePackageManifestBundle includes the requested fields of the GraphQL type Bundle.
-// The GraphQL type's documentation follows.
-//
-// A reusable infrastructure component that packages IaC modules, policies, runbooks, and cloud dependencies into a deliverable software component
-type getPackagePackageManifestBundle struct {
-	// Unique identifier
-	Id string `json:"id"`
-	// Name of the bundle
-	Name string `json:"name"`
-	// Raw massdriver.yaml spec
-	Spec map[string]any `json:"-"`
-	// Version of the bundle specification
-	SpecVersion string `json:"specVersion"`
-}
-
-// GetId returns getPackagePackageManifestBundle.Id, and is useful for accessing the field via an interface.
-func (v *getPackagePackageManifestBundle) GetId() string { return v.Id }
-
-// GetName returns getPackagePackageManifestBundle.Name, and is useful for accessing the field via an interface.
-func (v *getPackagePackageManifestBundle) GetName() string { return v.Name }
-
-// GetSpec returns getPackagePackageManifestBundle.Spec, and is useful for accessing the field via an interface.
-func (v *getPackagePackageManifestBundle) GetSpec() map[string]any { return v.Spec }
-
-// GetSpecVersion returns getPackagePackageManifestBundle.SpecVersion, and is useful for accessing the field via an interface.
-func (v *getPackagePackageManifestBundle) GetSpecVersion() string { return v.SpecVersion }
-
-func (v *getPackagePackageManifestBundle) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*getPackagePackageManifestBundle
-		Spec json.RawMessage `json:"spec"`
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.getPackagePackageManifestBundle = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	{
-		dst := &v.Spec
-		src := firstPass.Spec
-		if len(src) != 0 && string(src) != "null" {
-			err = scalars.UnmarshalJSON(
-				src, dst)
-			if err != nil {
-				return fmt.Errorf(
-					"unable to unmarshal getPackagePackageManifestBundle.Spec: %w", err)
-			}
-		}
-	}
-	return nil
-}
-
-type __premarshalgetPackagePackageManifestBundle struct {
-	Id string `json:"id"`
-
-	Name string `json:"name"`
-
-	Spec json.RawMessage `json:"spec"`
-
-	SpecVersion string `json:"specVersion"`
-}
-
-func (v *getPackagePackageManifestBundle) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
-}
-
-func (v *getPackagePackageManifestBundle) __premarshalJSON() (*__premarshalgetPackagePackageManifestBundle, error) {
-	var retval __premarshalgetPackagePackageManifestBundle
-
-	retval.Id = v.Id
-	retval.Name = v.Name
-	{
-
-		dst := &retval.Spec
-		src := v.Spec
-		var err error
-		*dst, err = scalars.MarshalJSON(
-			&src)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"unable to marshal getPackagePackageManifestBundle.Spec: %w", err)
-		}
-	}
-	retval.SpecVersion = v.SpecVersion
-	return &retval, nil
-}
 
 // getPackagePackageRemoteReferencesRemoteReference includes the requested fields of the GraphQL type RemoteReference.
 type getPackagePackageRemoteReferencesRemoteReference struct {
@@ -3646,6 +3653,12 @@ query getEnvironmentById ($organizationId: ID!, $id: ID!) {
 					field
 				}
 			}
+			bundle {
+				id
+				name
+				spec
+				specVersion
+			}
 			status
 			manifest {
 				id
@@ -3653,12 +3666,6 @@ query getEnvironmentById ($organizationId: ID!, $id: ID!) {
 				slug
 				suffix
 				description
-				bundle {
-					id
-					name
-					spec
-					specVersion
-				}
 			}
 		}
 		project {
@@ -3735,18 +3742,18 @@ query getEnvironmentsByProject ($organizationId: ID!, $projectId: ID!) {
 						field
 					}
 				}
+				bundle {
+					id
+					name
+					spec
+					specVersion
+				}
 				manifest {
 					id
 					name
 					slug
 					suffix
 					description
-					bundle {
-						id
-						name
-						spec
-						specVersion
-					}
 				}
 			}
 			project {
@@ -3806,18 +3813,18 @@ query getPackage ($organizationId: ID!, $id: ID!) {
 				field
 			}
 		}
+		bundle {
+			id
+			name
+			spec
+			specVersion
+		}
 		manifest {
 			id
 			name
 			slug
 			suffix
 			description
-			bundle {
-				id
-				name
-				spec
-				specVersion
-			}
 		}
 		environment {
 			id

--- a/pkg/bundle/publish.go
+++ b/pkg/bundle/publish.go
@@ -109,6 +109,8 @@ func getIgnores(ignorePath string) (*ignore.GitIgnore, error) {
 		"!/icon.svg",
 		"!/operator.md",
 		"!/operator.mdx",
+		"!/readme.md",
+		"!/README.md",
 		"!/schema-artifacts.json",
 		"!/schema-connections.json",
 		"!/schema-params.json",

--- a/pkg/commands/bundle/new.go
+++ b/pkg/commands/bundle/new.go
@@ -1,6 +1,7 @@
 package bundle
 
 import (
+	"fmt"
 	"path"
 
 	"github.com/massdriver-cloud/mass/pkg/bundle"
@@ -11,21 +12,21 @@ import (
 func RunNew(bundleCache templatecache.TemplateCache, templateData *templatecache.TemplateData) error {
 	renderErr := bundleCache.RenderTemplate(templateData)
 	if renderErr != nil {
-		return renderErr
+		return fmt.Errorf("failed to render template: %w", renderErr)
 	}
 
 	// if we imported params from existing IaC, pass that to the provisioner in case more initialization should be done
 	if templateData.ExistingParamsPath != "" {
 		b, unmarshalErr := bundle.Unmarshal(templateData.OutputDir)
 		if unmarshalErr != nil {
-			return unmarshalErr
+			return fmt.Errorf("failed to unmarshal bundle: %w", unmarshalErr)
 		}
 
 		for _, step := range b.Steps {
 			prov := provisioners.NewProvisioner(step.Provisioner)
 			initErr := prov.InitializeStep(path.Join(templateData.OutputDir, step.Path), templateData.ExistingParamsPath)
 			if initErr != nil {
-				return initErr
+				return fmt.Errorf("failed to initialize step %q: %w", step.Path, initErr)
 			}
 		}
 	}

--- a/pkg/commands/pkg/export.go
+++ b/pkg/commands/pkg/export.go
@@ -157,7 +157,7 @@ func ExportPackageWithConfig(ctx context.Context, config *ExportPackageConfig, p
 	}
 
 	if isRunning {
-		if err := writeBundleWithConfig(ctx, config, pkg.Manifest.Bundle, pkg.NamePrefix, directory); err != nil {
+		if err := writeBundleWithConfig(ctx, config, pkg.Bundle, pkg.NamePrefix, directory); err != nil {
 			return fmt.Errorf("failed to write bundle for package %s: %w", pkg.NamePrefix, err)
 		}
 	}
@@ -203,15 +203,15 @@ func validatePackageExport(pkg *api.Package) error {
 	}
 
 	if pkg.Status == string(api.PackageStatusProvisioned) {
-		if pkg.Manifest.Bundle == nil {
+		if pkg.Bundle == nil {
 			return fmt.Errorf("package %s bundle is nil", pkg.NamePrefix)
 		}
 
-		if pkg.Manifest.Bundle.Spec == nil {
+		if pkg.Bundle.Spec == nil {
 			return fmt.Errorf("package %s bundle spec is nil", pkg.NamePrefix)
 		}
 
-		if pkg.Manifest.Bundle.Name == "" {
+		if pkg.Bundle.Name == "" {
 			return fmt.Errorf("package %s bundle name is empty", pkg.NamePrefix)
 		}
 	}
@@ -261,7 +261,7 @@ func writeArtifactWithConfig(ctx context.Context, config *ExportPackageConfig, a
 
 func writeStateWithConfig(ctx context.Context, config *ExportPackageConfig, pkg *api.Package, directory string) error {
 	var unmarshalledBundle bundle.Bundle
-	mapstructure.Decode(pkg.Manifest.Bundle.Spec, &unmarshalledBundle)
+	mapstructure.Decode(pkg.Bundle.Spec, &unmarshalledBundle)
 
 	var steps []bundle.Step
 	if unmarshalledBundle.Steps != nil {

--- a/pkg/commands/pkg/export_test.go
+++ b/pkg/commands/pkg/export_test.go
@@ -94,20 +94,20 @@ func TestExportPackage(t *testing.T) {
 						Field: "output",
 					},
 				},
-				Manifest: &api.Manifest{
-					Slug: "test-manifest",
-					Bundle: &api.Bundle{
-						Name: "test-bundle",
-						Spec: map[string]any{
-							"steps": []map[string]any{
-								{
-									"path":        "src",
-									"provisioner": "terraform",
-								},
+				Bundle: &api.Bundle{
+					Name: "test-bundle",
+					Spec: map[string]any{
+						"steps": []map[string]any{
+							{
+								"path":        "src",
+								"provisioner": "terraform",
 							},
 						},
-						SpecVersion: "application/vnd.massdriver.bundle.v1+json",
 					},
+					SpecVersion: "application/vnd.massdriver.bundle.v1+json",
+				},
+				Manifest: &api.Manifest{
+					Slug: "test-manifest",
 				},
 			},
 			baseDir: "/tmp/export",
@@ -151,20 +151,20 @@ func TestExportPackage(t *testing.T) {
 						Field: "output",
 					},
 				},
-				Manifest: &api.Manifest{
-					Slug: "test-manifest",
-					Bundle: &api.Bundle{
-						Name: "test-bundle",
-						Spec: map[string]any{
-							"steps": []map[string]any{
-								{
-									"path":        "src",
-									"provisioner": "terraform",
-								},
+				Bundle: &api.Bundle{
+					Name: "test-bundle",
+					Spec: map[string]any{
+						"steps": []map[string]any{
+							{
+								"path":        "src",
+								"provisioner": "terraform",
 							},
 						},
-						SpecVersion: "application/vnd.massdriver.bundle.v0+json",
 					},
+					SpecVersion: "application/vnd.massdriver.bundle.v0+json",
+				},
+				Manifest: &api.Manifest{
+					Slug: "test-manifest",
 				},
 			},
 			baseDir: "/tmp/export",
@@ -204,11 +204,11 @@ func TestExportPackage(t *testing.T) {
 						},
 					},
 				},
+				Bundle: &api.Bundle{
+					Name: "external-bundle",
+				},
 				Manifest: &api.Manifest{
 					Slug: "external-manifest",
-					Bundle: &api.Bundle{
-						Name: "external-bundle",
-					},
 				},
 			},
 			baseDir: "/tmp/export",
@@ -229,11 +229,11 @@ func TestExportPackage(t *testing.T) {
 				ID:         "pkg-789",
 				NamePrefix: "pending-package-0001",
 				Status:     "PENDING",
+				Bundle: &api.Bundle{
+					Name: "pending-bundle",
+				},
 				Manifest: &api.Manifest{
 					Slug: "pending-manifest",
-					Bundle: &api.Bundle{
-						Name: "pending-bundle",
-					},
 				},
 			},
 			baseDir: "/tmp/export",
@@ -314,12 +314,12 @@ func TestExportPackage_FileSystemError(t *testing.T) {
 		ID:         "pkg-123",
 		NamePrefix: "test-package-0001",
 		Status:     string(api.PackageStatusProvisioned),
+		Bundle: &api.Bundle{
+			Name: "test-bundle",
+			Spec: map[string]any{},
+		},
 		Manifest: &api.Manifest{
 			Slug: "test-manifest",
-			Bundle: &api.Bundle{
-				Name: "test-bundle",
-				Spec: map[string]any{},
-			},
 		},
 	}
 


### PR DESCRIPTION
This PR refactors the GraphQL API to move bundle information from being nested under manifest to being a direct field on the package query response. The change affects how bundle data is accessed throughout the codebase.

**Key changes**:

* Moved Bundle field from Manifest type to Package type in GraphQL schema and API
* Updated all references from pkg.Manifest.Bundle to pkg.Bundle in export and validation logic
* Improved error handling in bundle creation with more descriptive error messages