### PR TITLE
Output repo instances url after publish

### DIFF
--- a/pkg/api/urls.go
+++ b/pkg/api/urls.go
@@ -61,3 +61,8 @@ func (u *URLHelper) PackageURL(projectSlug, environmentSlug, packageSlug string)
 func (u *URLHelper) BundleURL(bundleName, version string) string {
 	return fmt.Sprintf("%s/orgs/%s/repos/%s/%s", u.baseURL, u.orgID, bundleName, version)
 }
+
+// RepoInstancesURL returns the URL for bundle instances
+func (u *URLHelper) RepoInstancesURL(bundleName, version string) string {
+	return fmt.Sprintf("%s/orgs/%s/repos/%s/%s/instances", u.baseURL, u.orgID, bundleName, version)
+}

--- a/pkg/commands/bundle/publish.go
+++ b/pkg/commands/bundle/publish.go
@@ -53,6 +53,13 @@ func RunPublish(ctx context.Context, b *bundle.Bundle, mdClient *client.Client, 
 
 	fmt.Printf("Bundle %s:%s successfully published to organization %s!\n", printBundleName, version, printOrganizationId)
 
+	// Output repo instances URL
+	urlHelper, urlErr := api.NewURLHelper(ctx, mdClient)
+	if urlErr == nil {
+		instancesURL := urlHelper.RepoInstancesURL(b.Name, version)
+		fmt.Printf("Repo: %s\n", instancesURL)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Output the repo instances after publish.
<img width="866" height="172" alt="Screenshot 2025-11-04 at 12 02 10 PM" src="https://github.com/user-attachments/assets/1e808756-5698-4acd-a15e-ca8a82905309" />

<img width="1224" height="802" alt="Screenshot 2025-11-04 at 12 03 08 PM" src="https://github.com/user-attachments/assets/b04d1510-ef11-4cc7-91e4-374a2cad2d1c" />
