### PR TITLE
Setting the default make task to install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ MKFILE_DIR := $(dir $(MKFILE_PATH))
 API_DIR := pkg/api
 SCHEMA_URL ?= https://api.massdriver.cloud/graphql/schema.graphql
 
+.DEFAULT_GOAL := install
+
 all.macos: clean generate install.macos
 all.linux: clean generate install.linux
 
@@ -58,3 +60,15 @@ install.macos: build.macos
 .PHONY: install.linux
 install.linux: build.linux
 	cp -f bin/mass-linux-amd64 ${INSTALL_PATH}/mass
+
+.PHONY: install
+install: ## Install mass CLI (auto-detects macOS or Linux)
+	@OS="$$(uname -s)"; \
+	if [ "$$OS" = "Darwin" ]; then \
+		$(MAKE) install.macos; \
+	elif [ "$$OS" = "Linux" ]; then \
+		$(MAKE) install.linux; \
+	else \
+		echo "Unsupported OS: $$OS"; \
+		exit 1; \
+	fi


### PR DESCRIPTION
Setting the default make task to build and install to make it easier for anyone building from source. Also auto detects OS