### PR TITLE
Fix documentation link for mass CLI usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,5 +39,3 @@ If you'd like to contribute to the Mass CLI, please refer to the [Contribution G
 ## License
 
 The Mass CLI is open source software licensed under the [MIT license](https://github.com/massdriver-cloud/mass/blob/main/LICENSE).
-
-

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ go install github.com/massdriver-cloud/mass
 
 ## Usage
 
-The `mass` command line tool provides a number of subcommands to interact with Massdriver Cloud. For detailed usage and examples, please see the [official documentation](https://docs.massdriver.cloud/cli/overview).
+The `mass` command line tool provides a number of subcommands to interact with Massdriver Cloud. For detailed usage and examples, please see the [official documentation](https://docs.massdriver.cloud/cli/commands/mass).
 
 ## Contributing
 
@@ -39,3 +39,5 @@ If you'd like to contribute to the Mass CLI, please refer to the [Contribution G
 ## License
 
 The Mass CLI is open source software licensed under the [MIT license](https://github.com/massdriver-cloud/mass/blob/main/LICENSE).
+
+


### PR DESCRIPTION
Updated the link to the official documentation for the mass CLI.