### PR TITLE
add deployment approve/reject and plan/propose to instance deploy

### DIFF
--- a/cmd/deployment.go
+++ b/cmd/deployment.go
@@ -32,7 +32,7 @@ var deploymentTemplates embed.FS
 func NewCmdDeployment() *cobra.Command {
 	deploymentCmd := &cobra.Command{
 		Use:     "deployment",
-		Aliases: []string{"dep"},
+		Aliases: []string{"dep", "deploy"},
 		Short:   "Manage deployments",
 		Long:    helpdocs.MustRender("deployment"),
 	}
@@ -82,10 +82,30 @@ func NewCmdDeployment() *cobra.Command {
 	}
 	deploymentAbortCmd.Flags().BoolP("force", "f", false, "Skip confirmation prompt")
 
+	deploymentApproveCmd := &cobra.Command{
+		Use:     "approve <deployment-id>",
+		Short:   "Approve a proposed deployment, releasing it to run",
+		Example: `mass deployment approve 12345678-1234-1234-1234-123456789012`,
+		Long:    helpdocs.MustRender("deployment/approve"),
+		Args:    cobra.ExactArgs(1),
+		RunE:    runDeploymentApprove,
+	}
+
+	deploymentRejectCmd := &cobra.Command{
+		Use:     "reject <deployment-id>",
+		Short:   "Reject a proposed deployment, discarding it permanently",
+		Example: `mass deployment reject 12345678-1234-1234-1234-123456789012`,
+		Long:    helpdocs.MustRender("deployment/reject"),
+		Args:    cobra.ExactArgs(1),
+		RunE:    runDeploymentReject,
+	}
+
 	deploymentCmd.AddCommand(deploymentGetCmd)
 	deploymentCmd.AddCommand(deploymentListCmd)
 	deploymentCmd.AddCommand(deploymentLogsCmd)
 	deploymentCmd.AddCommand(deploymentAbortCmd)
+	deploymentCmd.AddCommand(deploymentApproveCmd)
+	deploymentCmd.AddCommand(deploymentRejectCmd)
 
 	return deploymentCmd
 }
@@ -262,6 +282,44 @@ func runDeploymentAbort(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("✅ Deployment `%s` aborted (status: %s)\n", aborted.ID, aborted.Status)
+	return nil
+}
+
+func runDeploymentApprove(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+	deploymentID := args[0]
+	cmd.SilenceUsage = true
+
+	mdClient, err := massdriver.NewClient()
+	if err != nil {
+		return fmt.Errorf("error initializing massdriver client: %w", err)
+	}
+
+	approved, err := mdClient.Deployments.Approve(ctx, deploymentID)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("✅ Deployment `%s` approved (status: %s)\n", approved.ID, approved.Status)
+	return nil
+}
+
+func runDeploymentReject(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+	deploymentID := args[0]
+	cmd.SilenceUsage = true
+
+	mdClient, err := massdriver.NewClient()
+	if err != nil {
+		return fmt.Errorf("error initializing massdriver client: %w", err)
+	}
+
+	rejected, err := mdClient.Deployments.Reject(ctx, deploymentID)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("✅ Deployment `%s` rejected (status: %s)\n", rejected.ID, rejected.Status)
 	return nil
 }
 

--- a/cmd/instance.go
+++ b/cmd/instance.go
@@ -37,19 +37,7 @@ func NewCmdInstance() *cobra.Command {
 		Long:    helpdocs.MustRender("instance"),
 	}
 
-	instanceDeployCmd := &cobra.Command{
-		Use:     `deploy <project>-<env>-<manifest>`,
-		Short:   "Deploy instances",
-		Example: `mass instance deploy ecomm-prod-vpc`,
-		Long:    helpdocs.MustRender("instance/deploy"),
-		Args:    cobra.ExactArgs(1),
-		RunE:    runInstanceDeploy,
-	}
-	instanceDeployCmd.Flags().StringP("message", "m", "", "Add a message when deploying")
-	instanceDeployCmd.Flags().StringP("params", "p", "", "Path to params json, tfvars or yaml file. Use '-' to read from stdin. When provided, the full configuration is replaced. Supports bash interpolation.")
-	instanceDeployCmd.Flags().StringArrayP("patch", "P", []string{}, "Patch the last deployed configuration using a JQ expression. Can be specified multiple times.")
-	instanceDeployCmd.Flags().BoolP("follow", "f", false, "Stream the deployment's logs to stdout until it completes")
-	instanceDeployCmd.MarkFlagsMutuallyExclusive("params", "patch")
+	instanceDeployCmd := newInstanceDeployCmd()
 
 	instanceExportCmd := &cobra.Command{
 		Use:     `export <project>-<env>-<manifest>`,
@@ -131,6 +119,26 @@ func NewCmdInstance() *cobra.Command {
 	instanceCmd.AddCommand(newInstanceCopyCmd())
 
 	return instanceCmd
+}
+
+func newInstanceDeployCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:     `deploy <project>-<env>-<manifest>`,
+		Short:   "Deploy instances",
+		Example: `mass instance deploy ecomm-prod-vpc`,
+		Long:    helpdocs.MustRender("instance/deploy"),
+		Args:    cobra.ExactArgs(1),
+		RunE:    runInstanceDeploy,
+	}
+	c.Flags().StringP("message", "m", "", "Add a message when deploying")
+	c.Flags().StringP("params", "p", "", "Path to params json, tfvars or yaml file. Use '-' to read from stdin. When provided, the full configuration is replaced. Supports bash interpolation.")
+	c.Flags().StringArrayP("patch", "P", []string{}, "Patch the last deployed configuration using a JQ expression. Can be specified multiple times.")
+	c.Flags().Bool("plan", false, "Run a dry-run plan (preview changes) instead of provisioning")
+	c.Flags().Bool("propose", false, "Create the deployment in PROPOSED status, awaiting approval before it runs")
+	c.Flags().BoolP("follow", "f", false, "Stream the deployment's logs to stdout until it completes")
+	c.MarkFlagsMutuallyExclusive("params", "patch")
+	c.MarkFlagsMutuallyExclusive("plan", "propose")
+	return c
 }
 
 func newInstanceCopyCmd() *cobra.Command {
@@ -232,15 +240,46 @@ func renderInstance(inst *types.Instance) error {
 	return nil
 }
 
+// resolveDeployAction maps the invoked command and its flags to a deployment
+// action: `destroy` decommissions, `deploy --plan` runs a dry-run plan, and
+// plain `deploy` provisions.
+func resolveDeployAction(cmd *cobra.Command) deployments.Action {
+	if cmd.Name() == "destroy" {
+		return deployments.ActionDecommission
+	}
+	if plan, _ := cmd.Flags().GetBool("plan"); plan {
+		return deployments.ActionPlan
+	}
+	return deployments.ActionProvision
+}
+
+// confirmDecommission prompts for typed confirmation before a decommission,
+// unless --force was passed. It returns whether the caller should proceed.
+func confirmDecommission(cmd *cobra.Command, name string) (bool, error) {
+	force, err := cmd.Flags().GetBool("force")
+	if err != nil {
+		return false, err
+	}
+	if force {
+		return true, nil
+	}
+	fmt.Printf("WARNING: This will permanently decommission instance `%s` and all its resources.\n", name)
+	fmt.Printf("Type `%s` to confirm decommission: ", name)
+	reader := bufio.NewReader(os.Stdin)
+	answer, _ := reader.ReadString('\n')
+	if strings.TrimSpace(answer) != name {
+		fmt.Println("Decommission cancelled.")
+		return false, nil
+	}
+	return true, nil
+}
+
 func runInstanceDeploy(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
 	name := args[0]
 
-	action := deployments.ActionProvision
-	if cmd.Name() == "destroy" {
-		action = deployments.ActionDecommission
-	}
+	action := resolveDeployAction(cmd)
 
 	msg, err := cmd.Flags().GetString("message")
 	if err != nil {
@@ -262,12 +301,18 @@ func runInstanceDeploy(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// propose is only defined on the deploy command; destroy returns false here.
+	propose, _ := cmd.Flags().GetBool("propose")
+
 	opts := instance.DeployOptions{
 		Action:       action,
 		Message:      msg,
 		PatchQueries: patchQueries,
+		Propose:      propose,
 	}
-	if follow {
+	// A proposed deployment doesn't run until it's approved, so there are no
+	// logs to follow.
+	if follow && !propose {
 		opts.LogWriter = os.Stdout
 	}
 
@@ -280,19 +325,12 @@ func runInstanceDeploy(cmd *cobra.Command, args []string) error {
 	}
 
 	if action == deployments.ActionDecommission {
-		force, forceErr := cmd.Flags().GetBool("force")
-		if forceErr != nil {
-			return forceErr
+		proceed, confirmErr := confirmDecommission(cmd, name)
+		if confirmErr != nil {
+			return confirmErr
 		}
-		if !force {
-			fmt.Printf("WARNING: This will permanently decommission instance `%s` and all its resources.\n", name)
-			fmt.Printf("Type `%s` to confirm decommission: ", name)
-			reader := bufio.NewReader(os.Stdin)
-			answer, _ := reader.ReadString('\n')
-			if strings.TrimSpace(answer) != name {
-				fmt.Println("Decommission cancelled.")
-				return nil
-			}
+		if !proceed {
+			return nil
 		}
 	}
 
@@ -303,16 +341,38 @@ func runInstanceDeploy(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("error initializing massdriver client: %w", err)
 	}
 
-	if _, err = instance.RunDeploy(ctx, instance.NewDeployAPI(mdClient), name, opts); err != nil {
+	deployment, err := instance.RunDeploy(ctx, instance.NewDeployAPI(mdClient), name, opts)
+	if err != nil {
 		return err
 	}
 
-	if action == deployments.ActionDecommission {
-		fmt.Printf("✅ Instance `%s` decommission started\n", name)
-		fmt.Printf("🔗 %s\n", mdClient.URLs.Helper(ctx).InstanceURL(name))
+	reportDeployOutcome(ctx, mdClient, action, name, propose, deployment)
+	return nil
+}
+
+// reportDeployOutcome prints the user-facing summary after a deployment is
+// created. Provision runs report their progress via the status-polling /
+// log-follow output, so they get no extra line here.
+func reportDeployOutcome(ctx context.Context, mdClient *massdriver.Client, action deployments.Action, name string, propose bool, deployment *types.Deployment) {
+	url := mdClient.URLs.Helper(ctx).InstanceURL(name)
+
+	if propose {
+		fmt.Printf("✅ Deployment `%s` proposed for instance `%s` (awaiting approval)\n", deployment.ID, name)
+		fmt.Printf("   Approve with: mass deployment approve %s\n", deployment.ID)
+		fmt.Printf("   Reject with:  mass deployment reject %s\n", deployment.ID)
+		fmt.Printf("🔗 %s\n", url)
+		return
 	}
 
-	return nil
+	switch action {
+	case deployments.ActionDecommission:
+		fmt.Printf("✅ Instance `%s` decommission started\n", name)
+		fmt.Printf("🔗 %s\n", url)
+	case deployments.ActionPlan:
+		fmt.Printf("✅ Plan started for instance `%s` (dry run — no changes are applied)\n", name)
+		fmt.Printf("🔗 %s\n", url)
+	case deployments.ActionProvision:
+	}
 }
 
 func readParams(path string) (map[string]any, error) {

--- a/docs/generated/mass_deployment.md
+++ b/docs/generated/mass_deployment.md
@@ -23,6 +23,7 @@ Use these commands to inspect and manage deployments:
 - `mass deployment approve <deployment-id>` — approve a proposed deployment, releasing it to run
 - `mass deployment reject <deployment-id>` — reject a proposed deployment, discarding it permanently
 
+
 ### Options
 
 ```

--- a/docs/generated/mass_deployment.md
+++ b/docs/generated/mass_deployment.md
@@ -14,13 +14,14 @@ Manage deployments
 
 A deployment is a single infrastructure provisioning operation against an instance — either `PROVISION` (apply), `DECOMMISSION` (tear down), or `PLAN` (dry run). Deployments are immutable once created.
 
-Use these commands to inspect deployment history and logs:
+Use these commands to inspect and manage deployments:
 
 - `mass deployment list <instance-id>` — list recent deployments for an instance
 - `mass deployment get <deployment-id>` — show details for a single deployment
 - `mass deployment logs <deployment-id>` — print log output from a deployment
 - `mass deployment abort <deployment-id>` — abort a pending, approved, or running deployment
-
+- `mass deployment approve <deployment-id>` — approve a proposed deployment, releasing it to run
+- `mass deployment reject <deployment-id>` — reject a proposed deployment, discarding it permanently
 
 ### Options
 
@@ -32,6 +33,8 @@ Use these commands to inspect deployment history and logs:
 
 * [mass](/cli/commands/mass)	 - Massdriver Cloud CLI
 * [mass deployment abort](/cli/commands/mass_deployment_abort)	 - Abort a pending, approved, or running deployment
+* [mass deployment approve](/cli/commands/mass_deployment_approve)	 - Approve a proposed deployment, releasing it to run
 * [mass deployment get](/cli/commands/mass_deployment_get)	 - Get a deployment by ID
 * [mass deployment list](/cli/commands/mass_deployment_list)	 - List deployments for an instance (most recent first)
 * [mass deployment logs](/cli/commands/mass_deployment_logs)	 - Stream the log output from a deployment
+* [mass deployment reject](/cli/commands/mass_deployment_reject)	 - Reject a proposed deployment, discarding it permanently

--- a/docs/generated/mass_deployment_approve.md
+++ b/docs/generated/mass_deployment_approve.md
@@ -1,0 +1,50 @@
+---
+id: mass_deployment_approve.md
+slug: /cli/commands/mass_deployment_approve
+title: Mass Deployment Approve
+sidebar_label: Mass Deployment Approve
+---
+## mass deployment approve
+
+Approve a proposed deployment, releasing it to run
+
+### Synopsis
+
+# Approve a Deployment
+
+Releases a `PROPOSED` deployment into the run queue. The deployment transitions to `APPROVED` and runs as soon as nothing else is running on the instance.
+
+Only valid for deployments currently in `PROPOSED` status. Create a proposal with `mass instance deploy <instance-id> --propose`.
+
+## Usage
+
+```shell
+mass deployment approve <deployment-id>
+```
+
+## Examples
+
+```shell
+mass deployment approve 12345678-1234-1234-1234-123456789012
+```
+
+
+```
+mass deployment approve <deployment-id> [flags]
+```
+
+### Examples
+
+```
+mass deployment approve 12345678-1234-1234-1234-123456789012
+```
+
+### Options
+
+```
+  -h, --help   help for approve
+```
+
+### SEE ALSO
+
+* [mass deployment](/cli/commands/mass_deployment)	 - Manage deployments

--- a/docs/generated/mass_deployment_reject.md
+++ b/docs/generated/mass_deployment_reject.md
@@ -1,0 +1,50 @@
+---
+id: mass_deployment_reject.md
+slug: /cli/commands/mass_deployment_reject
+title: Mass Deployment Reject
+sidebar_label: Mass Deployment Reject
+---
+## mass deployment reject
+
+Reject a proposed deployment, discarding it permanently
+
+### Synopsis
+
+# Reject a Deployment
+
+Discards a `PROPOSED` deployment permanently. The deployment transitions to `REJECTED`, which is terminal — rejected deployments never run.
+
+Only valid for deployments currently in `PROPOSED` status. To cancel a `PENDING`, `APPROVED`, or `RUNNING` deployment instead, use the `abort` flow.
+
+## Usage
+
+```shell
+mass deployment reject <deployment-id>
+```
+
+## Examples
+
+```shell
+mass deployment reject 12345678-1234-1234-1234-123456789012
+```
+
+
+```
+mass deployment reject <deployment-id> [flags]
+```
+
+### Examples
+
+```
+mass deployment reject 12345678-1234-1234-1234-123456789012
+```
+
+### Options
+
+```
+  -h, --help   help for reject
+```
+
+### SEE ALSO
+
+* [mass deployment](/cli/commands/mass_deployment)	 - Manage deployments

--- a/docs/generated/mass_instance_deploy.md
+++ b/docs/generated/mass_instance_deploy.md
@@ -56,6 +56,19 @@ mass instance deploy ecomm-prod-db --patch='.version = "13.4"'
 mass instance deploy ecomm-prod-db --patch='.version = "13.4"' --patch='.size = "large"'
 ```
 
+Run a dry-run plan to preview changes without provisioning. `--plan` combines with `--params`/`--patch` to preview a proposed configuration, and with `--follow` to stream the plan output:
+
+```shell
+mass instance deploy ecomm-prod-db --plan
+mass instance deploy ecomm-prod-db --plan --patch='.version = "13.4"' --follow
+```
+
+Propose a deployment for approval instead of running it immediately. The deployment is created in `PROPOSED` status and runs only once approved with `mass deployment approve` (or discarded with `mass deployment reject`). `--plan` and `--propose` cannot be combined:
+
+```shell
+mass instance deploy ecomm-prod-db --propose --message "bump db to 13.4" --patch='.version = "13.4"'
+```
+
 
 ```
 mass instance deploy <project>-<env>-<manifest> [flags]
@@ -75,6 +88,8 @@ mass instance deploy ecomm-prod-vpc
   -m, --message string      Add a message when deploying
   -p, --params string       Path to params json, tfvars or yaml file. Use '-' to read from stdin. When provided, the full configuration is replaced. Supports bash interpolation.
   -P, --patch stringArray   Patch the last deployed configuration using a JQ expression. Can be specified multiple times.
+      --plan                Run a dry-run plan (preview changes) instead of provisioning
+      --propose             Create the deployment in PROPOSED status, awaiting approval before it runs
 ```
 
 ### SEE ALSO

--- a/docs/helpdocs/deployment.md
+++ b/docs/helpdocs/deployment.md
@@ -2,9 +2,11 @@
 
 A deployment is a single infrastructure provisioning operation against an instance — either `PROVISION` (apply), `DECOMMISSION` (tear down), or `PLAN` (dry run). Deployments are immutable once created.
 
-Use these commands to inspect deployment history and logs:
+Use these commands to inspect and manage deployments:
 
 - `mass deployment list <instance-id>` — list recent deployments for an instance
 - `mass deployment get <deployment-id>` — show details for a single deployment
 - `mass deployment logs <deployment-id>` — print log output from a deployment
 - `mass deployment abort <deployment-id>` — abort a pending, approved, or running deployment
+- `mass deployment approve <deployment-id>` — approve a proposed deployment, releasing it to run
+- `mass deployment reject <deployment-id>` — reject a proposed deployment, discarding it permanently

--- a/docs/helpdocs/deployment/approve.md
+++ b/docs/helpdocs/deployment/approve.md
@@ -1,0 +1,17 @@
+# Approve a Deployment
+
+Releases a `PROPOSED` deployment into the run queue. The deployment transitions to `APPROVED` and runs as soon as nothing else is running on the instance.
+
+Only valid for deployments currently in `PROPOSED` status. Create a proposal with `mass instance deploy <instance-id> --propose`.
+
+## Usage
+
+```shell
+mass deployment approve <deployment-id>
+```
+
+## Examples
+
+```shell
+mass deployment approve 12345678-1234-1234-1234-123456789012
+```

--- a/docs/helpdocs/deployment/reject.md
+++ b/docs/helpdocs/deployment/reject.md
@@ -1,0 +1,17 @@
+# Reject a Deployment
+
+Discards a `PROPOSED` deployment permanently. The deployment transitions to `REJECTED`, which is terminal — rejected deployments never run.
+
+Only valid for deployments currently in `PROPOSED` status. To cancel a `PENDING`, `APPROVED`, or `RUNNING` deployment instead, use the `abort` flow.
+
+## Usage
+
+```shell
+mass deployment reject <deployment-id>
+```
+
+## Examples
+
+```shell
+mass deployment reject 12345678-1234-1234-1234-123456789012
+```

--- a/docs/helpdocs/instance/deploy.md
+++ b/docs/helpdocs/instance/deploy.md
@@ -43,3 +43,16 @@ Patch the last deployed configuration with one or more JQ expressions:
 mass instance deploy ecomm-prod-db --patch='.version = "13.4"'
 mass instance deploy ecomm-prod-db --patch='.version = "13.4"' --patch='.size = "large"'
 ```
+
+Run a dry-run plan to preview changes without provisioning. `--plan` combines with `--params`/`--patch` to preview a proposed configuration, and with `--follow` to stream the plan output:
+
+```shell
+mass instance deploy ecomm-prod-db --plan
+mass instance deploy ecomm-prod-db --plan --patch='.version = "13.4"' --follow
+```
+
+Propose a deployment for approval instead of running it immediately. The deployment is created in `PROPOSED` status and runs only once approved with `mass deployment approve` (or discarded with `mass deployment reject`). `--plan` and `--propose` cannot be combined:
+
+```shell
+mass instance deploy ecomm-prod-db --propose --message "bump db to 13.4" --patch='.version = "13.4"'
+```

--- a/internal/commands/instance/deploy.go
+++ b/internal/commands/instance/deploy.go
@@ -27,6 +27,7 @@ var DeploymentTimeout = time.Duration(5) * time.Minute
 type DeployAPI interface {
 	GetInstance(ctx context.Context, id string) (*types.Instance, error)
 	CreateDeployment(ctx context.Context, instanceID string, in deployments.CreateInput) (*types.Deployment, error)
+	ProposeDeployment(ctx context.Context, instanceID string, in deployments.ProposeInput) (*types.Deployment, error)
 	GetDeployment(ctx context.Context, id string) (*types.Deployment, error)
 	TailLogs(ctx context.Context, deploymentID string, w io.Writer) error
 }
@@ -42,6 +43,10 @@ func (s sdkDeployAPI) GetInstance(ctx context.Context, id string) (*types.Instan
 
 func (s sdkDeployAPI) CreateDeployment(ctx context.Context, instanceID string, in deployments.CreateInput) (*types.Deployment, error) {
 	return s.c.Deployments.Create(ctx, instanceID, in)
+}
+
+func (s sdkDeployAPI) ProposeDeployment(ctx context.Context, instanceID string, in deployments.ProposeInput) (*types.Deployment, error) {
+	return s.c.Deployments.Propose(ctx, instanceID, in)
 }
 
 func (s sdkDeployAPI) GetDeployment(ctx context.Context, id string) (*types.Deployment, error) {
@@ -62,6 +67,11 @@ type DeployOptions struct {
 	Params map[string]any
 	// PatchQueries are jq expressions applied to the resolved params prior to deploy.
 	PatchQueries []string
+	// Propose, when true, creates the deployment in PROPOSED status (awaiting
+	// approval) instead of running it immediately. RunDeploy returns as soon as
+	// the proposal is created and does not poll or stream logs. Not valid with
+	// ActionPlan (plans are non-destructive and need no approval gate).
+	Propose bool
 	// LogWriter, when non-nil, switches deployment-status output for live log
 	// streaming via the GraphQL subscriptions API. The status-polling chatter
 	// is suppressed; only log lines and the final outcome are written.
@@ -86,6 +96,16 @@ func RunDeploy(ctx context.Context, api DeployAPI, name string, opts DeployOptio
 	action := opts.Action
 	if action == "" {
 		action = deployments.ActionProvision
+	}
+
+	// A proposed deployment sits in PROPOSED until it is approved, so there's
+	// nothing to poll or stream — return the created proposal directly.
+	if opts.Propose {
+		return api.ProposeDeployment(ctx, inst.ID, deployments.ProposeInput{
+			Action:  action,
+			Message: opts.Message,
+			Params:  params,
+		})
 	}
 
 	deployment, err := api.CreateDeployment(ctx, inst.ID, deployments.CreateInput{

--- a/internal/commands/instance/deploy_test.go
+++ b/internal/commands/instance/deploy_test.go
@@ -23,6 +23,10 @@ type fakeDeployAPI struct {
 	gotCreateInput  deployments.CreateInput
 	gotCreateInstID string
 
+	proposeErr      error
+	gotProposeInput deployments.ProposeInput
+	proposeCalled   bool
+
 	finalDeployment  *types.Deployment
 	getDeploymentErr error
 }
@@ -44,6 +48,16 @@ func (f *fakeDeployAPI) CreateDeployment(_ context.Context, instanceID string, i
 	f.gotCreateInput = in
 	if f.createErr != nil {
 		return nil, f.createErr
+	}
+	return f.deployment, nil
+}
+
+func (f *fakeDeployAPI) ProposeDeployment(_ context.Context, instanceID string, in deployments.ProposeInput) (*types.Deployment, error) {
+	f.proposeCalled = true
+	f.gotCreateInstID = instanceID
+	f.gotProposeInput = in
+	if f.proposeErr != nil {
+		return nil, f.proposeErr
 	}
 	return f.deployment, nil
 }
@@ -156,6 +170,60 @@ func TestRunDeployWithDecommissionAction(t *testing.T) {
 	wantParams := map[string]any{"size": "small"}
 	if !reflect.DeepEqual(api.gotCreateInput.Params, wantParams) {
 		t.Errorf("got params %v, wanted %v", api.gotCreateInput.Params, wantParams)
+	}
+}
+
+func TestRunDeployWithPlanAction(t *testing.T) {
+	api := newDeployFake(map[string]any{"size": "small"}, "COMPLETED")
+	instance.DeploymentStatusSleep = 0 //nolint:reassign // intentionally overriding sleep duration in tests
+
+	_, err := instance.RunDeploy(t.Context(), api, "ecomm-prod-cache", instance.DeployOptions{
+		Action: deployments.ActionPlan,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if api.gotCreateInput.Action != deployments.ActionPlan {
+		t.Errorf("expected action PLAN, got %q", api.gotCreateInput.Action)
+	}
+
+	wantParams := map[string]any{"size": "small"}
+	if !reflect.DeepEqual(api.gotCreateInput.Params, wantParams) {
+		t.Errorf("got params %v, wanted %v", api.gotCreateInput.Params, wantParams)
+	}
+}
+
+func TestRunDeployProposeDoesNotPoll(t *testing.T) {
+	api := newDeployFake(map[string]any{"size": "small"}, "COMPLETED")
+	api.deployment = &types.Deployment{ID: "dep-1", Status: "PROPOSED"}
+	// A poll would panic here: finalDeployment is set, but GetDeployment must
+	// never be reached on the propose path.
+	api.finalDeployment = nil
+
+	dep, err := instance.RunDeploy(t.Context(), api, "ecomm-prod-cache", instance.DeployOptions{
+		Action:  deployments.ActionProvision,
+		Message: "please review",
+		Propose: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !api.proposeCalled {
+		t.Error("expected ProposeDeployment to be called")
+	}
+	if api.gotCreateInput.Action != "" {
+		t.Errorf("expected CreateDeployment not to be called, got action %q", api.gotCreateInput.Action)
+	}
+	if api.gotProposeInput.Action != deployments.ActionProvision {
+		t.Errorf("expected proposed action PROVISION, got %q", api.gotProposeInput.Action)
+	}
+	if api.gotProposeInput.Message != "please review" {
+		t.Errorf("got message %q, wanted %q", api.gotProposeInput.Message, "please review")
+	}
+	if dep.Status != "PROPOSED" {
+		t.Errorf("got status %s, wanted PROPOSED", dep.Status)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds deployment approval workflow support to the CLI: you can now propose a
deployment for review, and approve or reject it — mirroring the flow the web UI
already supports. Also adds `--plan` for dry-run previews on `mass instance
deploy`.

## Changes

### `mass instance deploy`
- **`--plan`** — create a dry-run `PLAN` deployment (preview changes without
  applying). Composes with `--params`/`--patch`/`--follow`. Provision-only.
- **`--propose`** — create the deployment in `PROPOSED` status instead of
  running it immediately. It runs only once approved. Returns as soon as the
  proposal is created (no polling/log-follow), printing the follow-up
  approve/reject commands.
- `--plan` and `--propose` are mutually exclusive.

### `mass deployment`
- **`mass deployment approve <deployment-id>`** — release a `PROPOSED`
  deployment to run (→ `APPROVED`).
- **`mass deployment reject <deployment-id>`** — discard a `PROPOSED`
  deployment permanently (→ `REJECTED`).

### Implementation
- `DeployAPI` gains `ProposeDeployment`; `DeployOptions.Propose` short-circuits
  `RunDeploy` to the SDK's `Propose` (PLAN is not proposable, per the SDK).
- Extracted `resolveDeployAction`, `confirmDecommission`, and
  `reportDeployOutcome` helpers to keep `runInstanceDeploy` within lint limits.