### PR TITLE
Add `mass env delete`

### DIFF
--- a/cmd/environment.go
+++ b/cmd/environment.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"embed"
@@ -95,6 +96,7 @@ func NewCmdEnvironment() *cobra.Command {
 	environmentCmd.AddCommand(environmentListCmd)
 	environmentCmd.AddCommand(environmentCreateCmd)
 	environmentCmd.AddCommand(environmentUpdateCmd)
+	environmentCmd.AddCommand(newEnvironmentDeleteCmd())
 	environmentCmd.AddCommand(environmentDefaultCmd)
 	environmentCmd.AddCommand(newEnvironmentPreviewCmd())
 	environmentCmd.AddCommand(newEnvironmentForkCmd())
@@ -102,6 +104,19 @@ func NewCmdEnvironment() *cobra.Command {
 	environmentCmd.AddCommand(newEnvironmentDecommissionCmd())
 
 	return environmentCmd
+}
+
+func newEnvironmentDeleteCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:     "delete [environment]",
+		Short:   "Delete an environment",
+		Example: `mass environment delete ecomm-staging`,
+		Long:    helpdocs.MustRender("environment/delete"),
+		Args:    cobra.ExactArgs(1),
+		RunE:    runEnvironmentDelete,
+	}
+	c.Flags().BoolP("force", "f", false, "Skip confirmation prompt")
+	return c
 }
 
 func newEnvironmentPreviewCmd() *cobra.Command {
@@ -423,6 +438,50 @@ func runEnvironmentUpdate(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("✅ Environment `%s` updated\n", updated.ID)
 	fmt.Printf("🔗 %s\n", mdClient.URLs.Helper(ctx).EnvironmentURL(updated.ID))
+	return nil
+}
+
+func runEnvironmentDelete(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	environmentID := args[0]
+	force, err := cmd.Flags().GetBool("force")
+	if err != nil {
+		return err
+	}
+
+	cmd.SilenceUsage = true
+
+	mdClient, err := massdriver.NewClient()
+	if err != nil {
+		return fmt.Errorf("error initializing massdriver client: %w", err)
+	}
+
+	env, err := mdClient.Environments.Get(ctx, environmentID)
+	if err != nil {
+		return fmt.Errorf("error getting environment: %w", err)
+	}
+
+	// Prompt for confirmation - requires typing the environment ID unless --force is used
+	if !force {
+		fmt.Printf("WARNING: This will permanently delete environment `%s`.\n", env.ID)
+		fmt.Printf("Type `%s` to confirm deletion: ", env.ID)
+		reader := bufio.NewReader(os.Stdin)
+		answer, _ := reader.ReadString('\n')
+		answer = strings.TrimSpace(answer)
+
+		if answer != env.ID {
+			fmt.Println("Deletion cancelled.")
+			return nil
+		}
+	}
+
+	deleted, err := mdClient.Environments.Delete(ctx, environmentID)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("✅ Environment `%s` deleted successfully\n", deleted.ID)
 	return nil
 }
 

--- a/docs/generated/mass_environment.md
+++ b/docs/generated/mass_environment.md
@@ -29,6 +29,7 @@ Environments can be modeled by application stage (production, staging, developme
 * [mass environment create](/cli/commands/mass_environment_create)	 - Create an environment
 * [mass environment decommission](/cli/commands/mass_environment_decommission)	 - Decommission every instance in an environment, in reverse dependency order
 * [mass environment default](/cli/commands/mass_environment_default)	 - Set an environment default connection
+* [mass environment delete](/cli/commands/mass_environment_delete)	 - Delete an environment
 * [mass environment deploy](/cli/commands/mass_environment_deploy)	 - Deploy every instance in an environment, in dependency order
 * [mass environment export](/cli/commands/mass_environment_export)	 - Export an environment from Massdriver
 * [mass environment fork](/cli/commands/mass_environment_fork)	 - Fork an existing environment

--- a/docs/generated/mass_environment_delete.md
+++ b/docs/generated/mass_environment_delete.md
@@ -1,0 +1,65 @@
+---
+id: mass_environment_delete.md
+slug: /cli/commands/mass_environment_delete
+title: Mass Environment Delete
+sidebar_label: Mass Environment Delete
+---
+## mass environment delete
+
+Delete an environment
+
+### Synopsis
+
+# Delete Environment
+
+Permanently deletes an environment. This action cannot be undone.
+
+Deleting an environment does not tear down its running infrastructure. Decommission the environment's instances first with `mass environment decommission` if you want the underlying resources removed.
+
+## Usage
+
+```bash
+mass environment delete <environment> [flags]
+```
+
+Where `<environment>` is the environment ID.
+
+## Flags
+
+- `--force, -f`: Skip confirmation prompt (useful for automation)
+
+## Confirmation
+
+By default, this command requires typing the environment ID to confirm deletion. This is a safety measure to prevent accidental deletions. Use the `--force` flag to skip this confirmation.
+
+## Examples
+
+```bash
+# Delete an environment (with confirmation)
+mass environment delete ecomm-staging
+
+# Delete an environment without confirmation prompt
+mass environment delete ecomm-staging --force
+```
+
+
+```
+mass environment delete [environment] [flags]
+```
+
+### Examples
+
+```
+mass environment delete ecomm-staging
+```
+
+### Options
+
+```
+  -f, --force   Skip confirmation prompt
+  -h, --help    help for delete
+```
+
+### SEE ALSO
+
+* [mass environment](/cli/commands/mass_environment)	 - Environment management

--- a/docs/helpdocs/environment/delete.md
+++ b/docs/helpdocs/environment/delete.md
@@ -1,0 +1,31 @@
+# Delete Environment
+
+Permanently deletes an environment. This action cannot be undone.
+
+Deleting an environment does not tear down its running infrastructure. Decommission the environment's instances first with `mass environment decommission` if you want the underlying resources removed.
+
+## Usage
+
+```bash
+mass environment delete <environment> [flags]
+```
+
+Where `<environment>` is the environment ID.
+
+## Flags
+
+- `--force, -f`: Skip confirmation prompt (useful for automation)
+
+## Confirmation
+
+By default, this command requires typing the environment ID to confirm deletion. This is a safety measure to prevent accidental deletions. Use the `--force` flag to skip this confirmation.
+
+## Examples
+
+```bash
+# Delete an environment (with confirmation)
+mass environment delete ecomm-staging
+
+# Delete an environment without confirmation prompt
+mass environment delete ecomm-staging --force
+```


### PR DESCRIPTION
Implements a `delete` subcommand for environments (aliased as `mass env delete`),
rounding out the environment CRUD lifecycle alongside `create`, `get`, `list`,
and `update`.

### What's new

- **`mass environment delete <environment>`** — permanently deletes an environment
  via the SDK's `Environments.Delete`.
- **`--force, -f`** flag to skip the confirmation prompt (for automation/CI).
- **Type-to-confirm safety prompt**: by default the user must type the environment
  ID to confirm, mirroring the existing `mass project delete` pattern. The
  environment is fetched first so the prompt shows the real ID and fails cleanly
  if it doesn't exist.

### Behavior notes

- Deleting an environment does **not** tear down its running infrastructure. The
  help doc calls this out and points users to `mass environment decommission`
  first if they want the underlying resources removed.