### PR TITLE
Add compare, clone, rollback, and remote-reference commands from SDK v0.2.10

### DIFF
--- a/cmd/compare.go
+++ b/cmd/compare.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/massdriver-cloud/mass/internal/cli"
+	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/platform/types"
+)
+
+// emptyDash renders an empty string as an em dash so blank cells read clearly.
+func emptyDash(s string) string {
+	if s == "" {
+		return "—"
+	}
+	return s
+}
+
+// paramValueCell renders one side of a leaf-level param comparison. A missing
+// key is shown as "—" to distinguish it from a present-but-empty value.
+func paramValueCell(v types.ParamValue) string {
+	if !v.Present {
+		return "—"
+	}
+	if v.Value == "" {
+		return `""`
+	}
+	return v.Value
+}
+
+// formatVersionComparison renders a version diff as "unchanged" or "src → tgt".
+func formatVersionComparison(v types.VersionComparison) string {
+	if v.Equal {
+		return fmt.Sprintf("%s (unchanged)", emptyDash(v.Source))
+	}
+	return fmt.Sprintf("%s → %s", emptyDash(v.Source), emptyDash(v.Target))
+}
+
+// printParamComparisons prints a table of leaf-level param diffs. When showAll
+// is false, only entries that differ are shown. Returns the number of params
+// that differ (regardless of showAll).
+func printParamComparisons(params []types.ParamComparison, showAll bool) int {
+	diffCount := 0
+	tbl := cli.NewTable("", "Path", "Source", "Target")
+	rows := 0
+	for _, p := range params {
+		if !p.Equal {
+			diffCount++
+		}
+		if p.Equal && !showAll {
+			continue
+		}
+		marker := "="
+		if !p.Equal {
+			marker = "≠"
+		}
+		tbl.AddRow(marker, p.Path, paramValueCell(p.Source), paramValueCell(p.Target))
+		rows++
+	}
+	if rows > 0 {
+		tbl.Print()
+	}
+	return diffCount
+}

--- a/cmd/deployment.go
+++ b/cmd/deployment.go
@@ -238,14 +238,6 @@ func runDeploymentLogs(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("error initializing massdriver client: %w", err)
 	}
 
-	return streamDeploymentLogs(ctx, mdClient, deploymentID)
-}
-
-// streamDeploymentLogs tails a deployment's logs to stdout until it reaches a
-// terminal status or ctx is cancelled. When streaming isn't available (no
-// personal access token) it falls back to a one-shot dump of the static logs
-// so the caller still sees the available history.
-func streamDeploymentLogs(ctx context.Context, mdClient *massdriver.Client, deploymentID string) error {
 	// TailLogs collapses backfill + terminal-check + live streaming into one call.
 	tailErr := mdClient.Deployments.TailLogs(ctx, deploymentID, os.Stdout)
 	if errors.Is(tailErr, deployments.ErrStreamingRequiresPAT) {

--- a/cmd/deployment.go
+++ b/cmd/deployment.go
@@ -100,12 +100,25 @@ func NewCmdDeployment() *cobra.Command {
 		RunE:    runDeploymentReject,
 	}
 
+	deploymentCompareCmd := &cobra.Command{
+		Use:     "compare <source-deployment-id> <target-deployment-id>",
+		Aliases: []string{"diff"},
+		Short:   "Compare two deployments' bundle version and params",
+		Example: `mass deployment compare 1111... 2222...`,
+		Long:    helpdocs.MustRender("deployment/compare"),
+		Args:    cobra.ExactArgs(2),
+		RunE:    runDeploymentCompare,
+	}
+	deploymentCompareCmd.Flags().StringP("output", "o", "text", "Output format (text or json)")
+	deploymentCompareCmd.Flags().Bool("all", false, "Show unchanged params too (default shows only differences)")
+
 	deploymentCmd.AddCommand(deploymentGetCmd)
 	deploymentCmd.AddCommand(deploymentListCmd)
 	deploymentCmd.AddCommand(deploymentLogsCmd)
 	deploymentCmd.AddCommand(deploymentAbortCmd)
 	deploymentCmd.AddCommand(deploymentApproveCmd)
 	deploymentCmd.AddCommand(deploymentRejectCmd)
+	deploymentCmd.AddCommand(deploymentCompareCmd)
 
 	return deploymentCmd
 }
@@ -225,6 +238,14 @@ func runDeploymentLogs(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("error initializing massdriver client: %w", err)
 	}
 
+	return streamDeploymentLogs(ctx, mdClient, deploymentID)
+}
+
+// streamDeploymentLogs tails a deployment's logs to stdout until it reaches a
+// terminal status or ctx is cancelled. When streaming isn't available (no
+// personal access token) it falls back to a one-shot dump of the static logs
+// so the caller still sees the available history.
+func streamDeploymentLogs(ctx context.Context, mdClient *massdriver.Client, deploymentID string) error {
 	// TailLogs collapses backfill + terminal-check + live streaming into one call.
 	tailErr := mdClient.Deployments.TailLogs(ctx, deploymentID, os.Stdout)
 	if errors.Is(tailErr, deployments.ErrStreamingRequiresPAT) {
@@ -242,6 +263,64 @@ func runDeploymentLogs(cmd *cobra.Command, args []string) error {
 		return tailErr
 	}
 	return nil
+}
+
+//nolint:dupl // parallel compare-command shape with runEnvironmentCompare; consolidating would couple unrelated commands
+func runDeploymentCompare(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+	sourceID := args[0]
+	targetID := args[1]
+
+	outputFormat, err := cmd.Flags().GetString("output")
+	if err != nil {
+		return err
+	}
+	showAll, err := cmd.Flags().GetBool("all")
+	if err != nil {
+		return err
+	}
+	cmd.SilenceUsage = true
+
+	mdClient, err := massdriver.NewClient()
+	if err != nil {
+		return fmt.Errorf("error initializing massdriver client: %w", err)
+	}
+
+	cmp, err := mdClient.Deployments.Compare(ctx, sourceID, targetID)
+	if err != nil {
+		return err
+	}
+
+	switch outputFormat {
+	case "json":
+		jsonBytes, marshalErr := json.MarshalIndent(cmp, "", "  ")
+		if marshalErr != nil {
+			return fmt.Errorf("failed to marshal comparison to JSON: %w", marshalErr)
+		}
+		fmt.Println(string(jsonBytes))
+		return nil
+	case "text":
+		printDeploymentComparison(cmp, showAll)
+		return nil
+	default:
+		return fmt.Errorf("unsupported output format: %s", outputFormat)
+	}
+}
+
+func printDeploymentComparison(cmp *types.DeploymentComparison, showAll bool) {
+	fmt.Println("Comparing deployments:")
+	fmt.Printf("  source: %s (%s)\n", cmp.Source.ID, cmp.Source.Status)
+	fmt.Printf("  target: %s (%s)\n\n", cmp.Target.ID, cmp.Target.Status)
+
+	fmt.Printf("Bundle version: %s\n\n", formatVersionComparison(cmp.Version))
+
+	diffs := printParamComparisons(cmp.Params, showAll)
+	fmt.Println()
+	if diffs == 0 {
+		fmt.Println("Params identical.")
+	} else {
+		fmt.Printf("%d param(s) differ.\n", diffs)
+	}
 }
 
 // signalContext returns a derived context that cancels on SIGINT/SIGTERM, so

--- a/cmd/environment.go
+++ b/cmd/environment.go
@@ -98,6 +98,7 @@ func NewCmdEnvironment() *cobra.Command {
 	environmentCmd.AddCommand(environmentUpdateCmd)
 	environmentCmd.AddCommand(newEnvironmentDeleteCmd())
 	environmentCmd.AddCommand(environmentDefaultCmd)
+	environmentCmd.AddCommand(newEnvironmentCompareCmd())
 	environmentCmd.AddCommand(newEnvironmentPreviewCmd())
 	environmentCmd.AddCommand(newEnvironmentForkCmd())
 	environmentCmd.AddCommand(newEnvironmentDeployCmd())
@@ -116,6 +117,21 @@ func newEnvironmentDeleteCmd() *cobra.Command {
 		RunE:    runEnvironmentDelete,
 	}
 	c.Flags().BoolP("force", "f", false, "Skip confirmation prompt")
+	return c
+}
+
+func newEnvironmentCompareCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:     "compare [source-environment] [target-environment]",
+		Aliases: []string{"diff"},
+		Short:   "Compare two environments instance-by-instance",
+		Example: `mass environment compare ecomm-staging ecomm-production`,
+		Long:    helpdocs.MustRender("environment/compare"),
+		Args:    cobra.ExactArgs(2),
+		RunE:    runEnvironmentCompare,
+	}
+	c.Flags().StringP("output", "o", "text", "Output format (text or json)")
+	c.Flags().Bool("all", false, "Show unchanged params and matching instances too (default shows only differences)")
 	return c
 }
 
@@ -692,4 +708,79 @@ func runEnvironmentDecommission(cmd *cobra.Command, args []string) error {
 		return environment.FollowEnvironment(ctx, environment.NewFollowAPI(mdClient), env.ID, os.Stdout)
 	}
 	return nil
+}
+
+//nolint:dupl // parallel compare-command shape with runDeploymentCompare; consolidating would couple unrelated commands
+func runEnvironmentCompare(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+	sourceID := args[0]
+	targetID := args[1]
+
+	outputFormat, err := cmd.Flags().GetString("output")
+	if err != nil {
+		return err
+	}
+	showAll, err := cmd.Flags().GetBool("all")
+	if err != nil {
+		return err
+	}
+	cmd.SilenceUsage = true
+
+	mdClient, err := massdriver.NewClient()
+	if err != nil {
+		return fmt.Errorf("error initializing massdriver client: %w", err)
+	}
+
+	cmp, err := mdClient.Environments.Compare(ctx, sourceID, targetID)
+	if err != nil {
+		return err
+	}
+
+	switch outputFormat {
+	case "json":
+		jsonBytes, marshalErr := json.MarshalIndent(cmp, "", "  ")
+		if marshalErr != nil {
+			return fmt.Errorf("failed to marshal comparison to JSON: %w", marshalErr)
+		}
+		fmt.Println(string(jsonBytes))
+		return nil
+	case "text":
+		printEnvironmentComparison(cmp, showAll)
+		return nil
+	default:
+		return fmt.Errorf("unsupported output format: %s", outputFormat)
+	}
+}
+
+func printEnvironmentComparison(cmp *types.EnvironmentComparison, showAll bool) {
+	fmt.Println("Comparing environments:")
+	fmt.Printf("  source: %s (%s)\n", cmp.Source.ID, cmp.Source.Name)
+	fmt.Printf("  target: %s (%s)\n\n", cmp.Target.ID, cmp.Target.Name)
+
+	changed := 0
+	for _, ic := range cmp.Instances {
+		if !ic.Equal {
+			changed++
+		}
+		if ic.Equal && !showAll {
+			continue
+		}
+
+		fmt.Printf("── %s ──\n", ic.Component.Name)
+		switch {
+		case ic.Source == nil:
+			fmt.Println("  (only in target)")
+		case ic.Target == nil:
+			fmt.Println("  (only in source)")
+		}
+		fmt.Printf("  bundle version: %s\n", formatVersionComparison(ic.Version))
+		printParamComparisons(ic.Params, showAll)
+		fmt.Println()
+	}
+
+	if changed == 0 {
+		fmt.Println("Environments identical.")
+	} else {
+		fmt.Printf("%d instance(s) differ.\n", changed)
+	}
 }

--- a/cmd/instance.go
+++ b/cmd/instance.go
@@ -117,8 +117,53 @@ func NewCmdInstance() *cobra.Command {
 	instanceCmd.AddCommand(instanceDestroyCmd)
 	instanceCmd.AddCommand(instanceOrphanCmd)
 	instanceCmd.AddCommand(newInstanceCopyCmd())
+	instanceCmd.AddCommand(newInstanceRollbackCmd())
+	instanceCmd.AddCommand(newInstanceRemoteReferenceCmd())
 
 	return instanceCmd
+}
+
+func newInstanceRollbackCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     `rollback <deployment-id>`,
+		Short:   "Propose rolling an instance back to a past completed deployment",
+		Example: `mass instance rollback 12345678-1234-1234-1234-123456789012`,
+		Long:    helpdocs.MustRender("instance/rollback"),
+		Args:    cobra.ExactArgs(1),
+		RunE:    runInstanceRollback,
+	}
+}
+
+func newInstanceRemoteReferenceCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:     "remote-reference",
+		Aliases: []string{"remote-ref"},
+		Short:   "Manage an instance's remote-reference connection overrides",
+		Long:    helpdocs.MustRender("instance/remote-reference"),
+	}
+
+	setCmd := &cobra.Command{
+		Use:     "set <instance-id> <field> <resource-id>",
+		Short:   "Override a connection slot with a resource from another project",
+		Example: `mass instance remote-reference set ecomm-prod-api database ecomm-prod-db.postgres`,
+		Long:    helpdocs.MustRender("instance/remote-reference-set"),
+		Args:    cobra.ExactArgs(3),
+		RunE:    runInstanceRemoteReferenceSet,
+	}
+
+	removeCmd := &cobra.Command{
+		Use:     "remove <instance-id> <field>",
+		Aliases: []string{"rm", "unset"},
+		Short:   "Remove a connection slot override, reverting to the blueprint wiring",
+		Example: `mass instance remote-reference remove ecomm-prod-api database`,
+		Long:    helpdocs.MustRender("instance/remote-reference-remove"),
+		Args:    cobra.ExactArgs(2),
+		RunE:    runInstanceRemoteReferenceRemove,
+	}
+
+	c.AddCommand(setCmd)
+	c.AddCommand(removeCmd)
+	return c
 }
 
 func newInstanceDeployCmd() *cobra.Command {
@@ -531,6 +576,72 @@ func runInstanceOrphan(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("✅ Instance `%s` orphaned (status: %s)\n", orphaned.ID, orphaned.Status)
 	fmt.Printf("🔗 %s\n", mdClient.URLs.Helper(ctx).InstanceURL(orphaned.ID))
+	return nil
+}
+
+func runInstanceRollback(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+	deploymentID := args[0]
+	cmd.SilenceUsage = true
+
+	mdClient, err := massdriver.NewClient()
+	if err != nil {
+		return fmt.Errorf("error initializing massdriver client: %w", err)
+	}
+
+	proposed, err := mdClient.Deployments.Rollback(ctx, deploymentID)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("✅ Rollback to deployment `%s` proposed as deployment `%s` (awaiting approval)\n", deploymentID, proposed.ID)
+	fmt.Printf("   Approve with: mass deployment approve %s\n", proposed.ID)
+	fmt.Printf("   Reject with:  mass deployment reject %s\n", proposed.ID)
+	if proposed.Instance != nil {
+		fmt.Printf("🔗 %s\n", mdClient.URLs.Helper(ctx).InstanceURL(proposed.Instance.ID))
+	}
+	return nil
+}
+
+func runInstanceRemoteReferenceSet(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+	instanceID := args[0]
+	field := args[1]
+	resourceID := args[2]
+	cmd.SilenceUsage = true
+
+	mdClient, err := massdriver.NewClient()
+	if err != nil {
+		return fmt.Errorf("error initializing massdriver client: %w", err)
+	}
+
+	ref, err := mdClient.Instances.SetRemoteReference(ctx, instanceID, resourceID, field)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("✅ Instance `%s` field `%s` now references resource `%s`\n", instanceID, ref.Field, ref.Resource.ID)
+	fmt.Printf("🔗 %s\n", mdClient.URLs.Helper(ctx).InstanceURL(instanceID))
+	return nil
+}
+
+func runInstanceRemoteReferenceRemove(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+	instanceID := args[0]
+	field := args[1]
+	cmd.SilenceUsage = true
+
+	mdClient, err := massdriver.NewClient()
+	if err != nil {
+		return fmt.Errorf("error initializing massdriver client: %w", err)
+	}
+
+	if _, err := mdClient.Instances.RemoveRemoteReference(ctx, instanceID, field); err != nil {
+		return err
+	}
+
+	fmt.Printf("✅ Instance `%s` field `%s` remote reference removed (reverted to blueprint wiring)\n", instanceID, field)
+	fmt.Printf("🔗 %s\n", mdClient.URLs.Helper(ctx).InstanceURL(instanceID))
 	return nil
 }
 

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -58,6 +58,8 @@ func NewCmdProject() *cobra.Command {
 		RunE:    runProjectList,
 	}
 	projectListCmd.Flags().StringP("output", "o", "table", "Output format (table, json)")
+	projectListCmd.Flags().String("name", "", "Filter to projects whose name exactly matches")
+	projectListCmd.Flags().String("search", "", "Free-text search across project name and description")
 
 	projectCreateCmd := &cobra.Command{
 		Use:   "create [slug]",
@@ -89,12 +91,25 @@ func NewCmdProject() *cobra.Command {
 	}
 	projectDeleteCmd.Flags().BoolP("force", "f", false, "Skip confirmation prompt")
 
+	projectCloneCmd := &cobra.Command{
+		Use:     "clone [source-project] [new-id]",
+		Short:   "Clone a project's blueprint into a new project",
+		Example: `mass project clone ecomm ecomm-copy`,
+		Long:    helpdocs.MustRender("project/clone"),
+		Args:    cobra.ExactArgs(2),
+		RunE:    runProjectClone,
+	}
+	projectCloneCmd.Flags().StringP("name", "n", "", "New project name (defaults to new-id if not provided)")
+	projectCloneCmd.Flags().StringP("description", "d", "", "Optional project description")
+	projectCloneCmd.Flags().StringToStringP("attributes", "a", nil, "Custom attributes for ABAC (e.g. -a team=ops,system=api)")
+
 	projectCmd.AddCommand(projectExportCmd)
 	projectCmd.AddCommand(projectGetCmd)
 	projectCmd.AddCommand(projectListCmd)
 	projectCmd.AddCommand(projectCreateCmd)
 	projectCmd.AddCommand(projectUpdateCmd)
 	projectCmd.AddCommand(projectDeleteCmd)
+	projectCmd.AddCommand(projectCloneCmd)
 
 	return projectCmd
 }
@@ -159,13 +174,15 @@ func runProjectList(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	name, _ := cmd.Flags().GetString("name")
+	search, _ := cmd.Flags().GetString("search")
 
 	mdClient, err := massdriver.NewClient()
 	if err != nil {
 		return fmt.Errorf("error initializing massdriver client: %w", err)
 	}
 
-	seq := mdClient.Projects.Iter(ctx, projects.ListInput{})
+	seq := mdClient.Projects.Iter(ctx, projects.ListInput{Name: name, Search: search})
 
 	switch output {
 	case "json":
@@ -271,6 +288,51 @@ func runProjectCreate(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("✅ Project `%s` created successfully\n", proj.ID)
+	fmt.Printf("🔗 %s\n", mdClient.URLs.Helper(ctx).ProjectURL(proj.ID))
+	return nil
+}
+
+func runProjectClone(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	sourceID := args[0]
+	newID := args[1]
+	name, err := cmd.Flags().GetString("name")
+	if err != nil {
+		return err
+	}
+	if name == "" {
+		name = newID
+	}
+	description, err := cmd.Flags().GetString("description")
+	if err != nil {
+		return err
+	}
+	attrs, err := cmd.Flags().GetStringToString("attributes")
+	if err != nil {
+		return err
+	}
+
+	cmd.SilenceUsage = true
+
+	mdClient, err := massdriver.NewClient()
+	if err != nil {
+		return fmt.Errorf("error initializing massdriver client: %w", err)
+	}
+
+	input := projects.CloneInput{
+		ID:          newID,
+		Name:        name,
+		Description: description,
+		Attributes:  cli.AttributesToAnyMap(attrs),
+	}
+
+	proj, err := mdClient.Projects.Clone(ctx, sourceID, input)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("✅ Project `%s` cloned from `%s`\n", proj.ID, sourceID)
 	fmt.Printf("🔗 %s\n", mdClient.URLs.Helper(ctx).ProjectURL(proj.ID))
 	return nil
 }

--- a/docs/generated/mass_deployment.md
+++ b/docs/generated/mass_deployment.md
@@ -35,6 +35,7 @@ Use these commands to inspect and manage deployments:
 * [mass](/cli/commands/mass)	 - Massdriver Cloud CLI
 * [mass deployment abort](/cli/commands/mass_deployment_abort)	 - Abort a pending, approved, or running deployment
 * [mass deployment approve](/cli/commands/mass_deployment_approve)	 - Approve a proposed deployment, releasing it to run
+* [mass deployment compare](/cli/commands/mass_deployment_compare)	 - Compare two deployments' bundle version and params
 * [mass deployment get](/cli/commands/mass_deployment_get)	 - Get a deployment by ID
 * [mass deployment list](/cli/commands/mass_deployment_list)	 - List deployments for an instance (most recent first)
 * [mass deployment logs](/cli/commands/mass_deployment_logs)	 - Stream the log output from a deployment

--- a/docs/generated/mass_deployment_compare.md
+++ b/docs/generated/mass_deployment_compare.md
@@ -1,0 +1,66 @@
+---
+id: mass_deployment_compare.md
+slug: /cli/commands/mass_deployment_compare
+title: Mass Deployment Compare
+sidebar_label: Mass Deployment Compare
+---
+## mass deployment compare
+
+Compare two deployments' bundle version and params
+
+### Synopsis
+
+# Compare Deployments
+
+Diffs two deployments' snapshotted configuration: the bundle version on each side plus a flat, leaf-level diff of the params.
+
+Use it to audit what a deploy changed ("what did this deployment do to the params?") or to contrast deploys from different points in time. Runtime state, logs, and produced artifacts are out of scope.
+
+The two deployments need not target the same instance, though comparing unrelated instances naturally reports every param as present on one side only.
+
+## Usage
+
+```bash
+mass deployment compare <source-deployment-id> <target-deployment-id> [flags]
+```
+
+## Flags
+
+- `--output, -o`: Output format, `text` (default) or `json`
+- `--all`: Show unchanged params too (by default only differing params are shown)
+
+## Examples
+
+```bash
+# Show only the params that changed between two deployments
+mass deployment compare 1111... 2222...
+
+# Show every param, changed or not
+mass deployment compare 1111... 2222... --all
+
+# Machine-readable output
+mass deployment compare 1111... 2222... -o json
+```
+
+
+```
+mass deployment compare <source-deployment-id> <target-deployment-id> [flags]
+```
+
+### Examples
+
+```
+mass deployment compare 1111... 2222...
+```
+
+### Options
+
+```
+      --all             Show unchanged params too (default shows only differences)
+  -h, --help            help for compare
+  -o, --output string   Output format (text or json) (default "text")
+```
+
+### SEE ALSO
+
+* [mass deployment](/cli/commands/mass_deployment)	 - Manage deployments

--- a/docs/generated/mass_environment.md
+++ b/docs/generated/mass_environment.md
@@ -26,6 +26,7 @@ Environments can be modeled by application stage (production, staging, developme
 ### SEE ALSO
 
 * [mass](/cli/commands/mass)	 - Massdriver Cloud CLI
+* [mass environment compare](/cli/commands/mass_environment_compare)	 - Compare two environments instance-by-instance
 * [mass environment create](/cli/commands/mass_environment_create)	 - Create an environment
 * [mass environment decommission](/cli/commands/mass_environment_decommission)	 - Decommission every instance in an environment, in reverse dependency order
 * [mass environment default](/cli/commands/mass_environment_default)	 - Set an environment default connection

--- a/docs/generated/mass_environment_compare.md
+++ b/docs/generated/mass_environment_compare.md
@@ -1,0 +1,66 @@
+---
+id: mass_environment_compare.md
+slug: /cli/commands/mass_environment_compare
+title: Mass Environment Compare
+sidebar_label: Mass Environment Compare
+---
+## mass environment compare
+
+Compare two environments instance-by-instance
+
+### Synopsis
+
+# Compare Environments
+
+Performs a side-by-side comparison of two environments in the same project, instance-by-instance.
+
+Instances are paired across environments by their underlying component. For each pair the comparison reports the bundle version diff and a flat, leaf-level diff of the params. When only one environment has an instance for a component, it is reported as present on that side only.
+
+Environment-level attributes and default resource wiring are out of scope.
+
+## Usage
+
+```bash
+mass environment compare <source-environment> <target-environment> [flags]
+```
+
+## Flags
+
+- `--output, -o`: Output format, `text` (default) or `json`
+- `--all`: Show unchanged params and matching instances too (by default only differences are shown)
+
+## Examples
+
+```bash
+# Show what differs between staging and production
+mass environment compare ecomm-staging ecomm-production
+
+# Include matching instances and unchanged params
+mass environment compare ecomm-staging ecomm-production --all
+
+# Machine-readable output
+mass environment compare ecomm-staging ecomm-production -o json
+```
+
+
+```
+mass environment compare [source-environment] [target-environment] [flags]
+```
+
+### Examples
+
+```
+mass environment compare ecomm-staging ecomm-production
+```
+
+### Options
+
+```
+      --all             Show unchanged params and matching instances too (default shows only differences)
+  -h, --help            help for compare
+  -o, --output string   Output format (text or json) (default "text")
+```
+
+### SEE ALSO
+
+* [mass environment](/cli/commands/mass_environment)	 - Environment management

--- a/docs/generated/mass_instance.md
+++ b/docs/generated/mass_instance.md
@@ -37,4 +37,6 @@ Instances are used to:
 * [mass instance get](/cli/commands/mass_instance_get)	 - Get an instance
 * [mass instance list](/cli/commands/mass_instance_list)	 - List instances in an environment
 * [mass instance orphan](/cli/commands/mass_instance_orphan)	 - Orphan an instance (reset to INITIALIZED, optionally clearing state locks)
+* [mass instance remote-reference](/cli/commands/mass_instance_remote-reference)	 - Manage an instance's remote-reference connection overrides
+* [mass instance rollback](/cli/commands/mass_instance_rollback)	 - Propose rolling an instance back to a past completed deployment
 * [mass instance version](/cli/commands/mass_instance_version)	 - Set instance version

--- a/docs/generated/mass_instance_remote-reference.md
+++ b/docs/generated/mass_instance_remote-reference.md
@@ -1,0 +1,37 @@
+---
+id: mass_instance_remote-reference.md
+slug: /cli/commands/mass_instance_remote-reference
+title: Mass Instance Remote-Reference
+sidebar_label: Mass Instance Remote-Reference
+---
+## mass instance remote-reference
+
+Manage an instance's remote-reference connection overrides
+
+### Synopsis
+
+# Instance Remote References
+
+A remote reference is a per-instance override of a single connection slot, pointing the slot at a resource from another project (or an imported resource) instead of the blueprint Link's wiring.
+
+The override takes priority over any blueprint-level Link wired into the same slot, and reverts to the Link (or environment default) when removed.
+
+## Subcommands
+
+- `set` — override a connection slot with a specific resource
+- `remove` — remove the override, reverting to the blueprint wiring
+
+See `mass instance remote-reference set --help` and `mass instance remote-reference remove --help` for details.
+
+
+### Options
+
+```
+  -h, --help   help for remote-reference
+```
+
+### SEE ALSO
+
+* [mass instance](/cli/commands/mass_instance)	 - Manage instances of IaC deployed in environments.
+* [mass instance remote-reference remove](/cli/commands/mass_instance_remote-reference_remove)	 - Remove a connection slot override, reverting to the blueprint wiring
+* [mass instance remote-reference set](/cli/commands/mass_instance_remote-reference_set)	 - Override a connection slot with a resource from another project

--- a/docs/generated/mass_instance_remote-reference_remove.md
+++ b/docs/generated/mass_instance_remote-reference_remove.md
@@ -1,0 +1,52 @@
+---
+id: mass_instance_remote-reference_remove.md
+slug: /cli/commands/mass_instance_remote-reference_remove
+title: Mass Instance Remote-Reference Remove
+sidebar_label: Mass Instance Remote-Reference Remove
+---
+## mass instance remote-reference remove
+
+Remove a connection slot override, reverting to the blueprint wiring
+
+### Synopsis
+
+# Remove an Instance Remote Reference
+
+Removes a per-instance connection slot override, reverting the slot to the blueprint Link's wiring (or the environment default).
+
+Like other configuration changes, the instance must not be in PROVISIONED or FAILED status.
+
+## Usage
+
+```bash
+mass instance remote-reference remove <instance-id> <field>
+```
+
+Where `<field>` is the connection slot key whose override should be removed.
+
+## Examples
+
+```bash
+mass instance remote-reference remove ecomm-prod-api database
+```
+
+
+```
+mass instance remote-reference remove <instance-id> <field> [flags]
+```
+
+### Examples
+
+```
+mass instance remote-reference remove ecomm-prod-api database
+```
+
+### Options
+
+```
+  -h, --help   help for remove
+```
+
+### SEE ALSO
+
+* [mass instance remote-reference](/cli/commands/mass_instance_remote-reference)	 - Manage an instance's remote-reference connection overrides

--- a/docs/generated/mass_instance_remote-reference_set.md
+++ b/docs/generated/mass_instance_remote-reference_set.md
@@ -1,0 +1,59 @@
+---
+id: mass_instance_remote-reference_set.md
+slug: /cli/commands/mass_instance_remote-reference_set
+title: Mass Instance Remote-Reference Set
+sidebar_label: Mass Instance Remote-Reference Set
+---
+## mass instance remote-reference set
+
+Override a connection slot with a resource from another project
+
+### Synopsis
+
+# Set an Instance Remote Reference
+
+Overrides one of an instance's connection slots with a resource from another project (or an imported resource).
+
+The override takes priority over any blueprint-level Link wired into the same slot, and reverts to the Link (or environment default) when removed with `mass instance remote-reference remove`.
+
+Like other configuration changes, the instance must not be in PROVISIONED or FAILED status.
+
+## Usage
+
+```bash
+mass instance remote-reference set <instance-id> <field> <resource-id>
+```
+
+- `<field>` is the key in the instance's bundle `connectionsSchema` to bind.
+- `<resource-id>` is either a UUID (for imported resources) or `instance.field` (for provisioned resources).
+
+## Examples
+
+```bash
+# Point the "database" connection slot at a resource produced by another instance
+mass instance remote-reference set ecomm-prod-api database ecomm-prod-db.postgres
+
+# Point a slot at an imported resource by UUID
+mass instance remote-reference set ecomm-prod-api database 12345678-1234-1234-1234-123456789012
+```
+
+
+```
+mass instance remote-reference set <instance-id> <field> <resource-id> [flags]
+```
+
+### Examples
+
+```
+mass instance remote-reference set ecomm-prod-api database ecomm-prod-db.postgres
+```
+
+### Options
+
+```
+  -h, --help   help for set
+```
+
+### SEE ALSO
+
+* [mass instance remote-reference](/cli/commands/mass_instance_remote-reference)	 - Manage an instance's remote-reference connection overrides

--- a/docs/generated/mass_instance_rollback.md
+++ b/docs/generated/mass_instance_rollback.md
@@ -14,7 +14,7 @@ Propose rolling an instance back to a past completed deployment
 
 Proposes a return to a past deployment's exact state. Given a historical deployment — which must be a COMPLETED PROVISION — this creates a new PROPOSED PROVISION deployment that snapshots the source deployment's params, connection wiring, bundle version, and release.
 
-The returned proposal goes through the normal review flow: approve it with `mass deployment approve`, discard it with `mass deployment reject`, or preview it with `mass instance plan`. On approval, the instance is pinned to the source deployment's exact bundle version, params, and connection snapshot — overriding whatever release is currently configured.
+The returned proposal goes through the normal review flow: approve it with `mass deployment approve` or discard it with `mass deployment reject`. On approval, the instance is pinned to the source deployment's exact bundle version, params, and connection snapshot — overriding whatever release is currently configured.
 
 ## Usage
 

--- a/docs/generated/mass_instance_rollback.md
+++ b/docs/generated/mass_instance_rollback.md
@@ -1,0 +1,56 @@
+---
+id: mass_instance_rollback.md
+slug: /cli/commands/mass_instance_rollback
+title: Mass Instance Rollback
+sidebar_label: Mass Instance Rollback
+---
+## mass instance rollback
+
+Propose rolling an instance back to a past completed deployment
+
+### Synopsis
+
+# Roll an Instance Back
+
+Proposes a return to a past deployment's exact state. Given a historical deployment — which must be a COMPLETED PROVISION — this creates a new PROPOSED PROVISION deployment that snapshots the source deployment's params, connection wiring, bundle version, and release.
+
+The returned proposal goes through the normal review flow: approve it with `mass deployment approve`, discard it with `mass deployment reject`, or preview it with `mass instance plan`. On approval, the instance is pinned to the source deployment's exact bundle version, params, and connection snapshot — overriding whatever release is currently configured.
+
+## Usage
+
+```bash
+mass instance rollback <deployment-id>
+```
+
+Where `<deployment-id>` is the historical COMPLETED PROVISION deployment to return to.
+
+## Examples
+
+```bash
+# Propose rolling back to a known-good past deployment
+mass instance rollback 12345678-1234-1234-1234-123456789012
+
+# Then approve it to apply
+mass deployment approve <proposed-deployment-id>
+```
+
+
+```
+mass instance rollback <deployment-id> [flags]
+```
+
+### Examples
+
+```
+mass instance rollback 12345678-1234-1234-1234-123456789012
+```
+
+### Options
+
+```
+  -h, --help   help for rollback
+```
+
+### SEE ALSO
+
+* [mass instance](/cli/commands/mass_instance)	 - Manage instances of IaC deployed in environments.

--- a/docs/generated/mass_project.md
+++ b/docs/generated/mass_project.md
@@ -26,6 +26,7 @@ A project can encompass many environments (permanent or ephemeral) and manages t
 ### SEE ALSO
 
 * [mass](/cli/commands/mass)	 - Massdriver Cloud CLI
+* [mass project clone](/cli/commands/mass_project_clone)	 - Clone a project's blueprint into a new project
 * [mass project create](/cli/commands/mass_project_create)	 - Create a project
 * [mass project delete](/cli/commands/mass_project_delete)	 - Delete a project
 * [mass project export](/cli/commands/mass_project_export)	 - Export a project from Massdriver

--- a/docs/generated/mass_project_clone.md
+++ b/docs/generated/mass_project_clone.md
@@ -1,0 +1,66 @@
+---
+id: mass_project_clone.md
+slug: /cli/commands/mass_project_clone
+title: Mass Project Clone
+sidebar_label: Mass Project Clone
+---
+## mass project clone
+
+Clone a project's blueprint into a new project
+
+### Synopsis
+
+# Clone Project
+
+Creates a new project by copying another project's blueprint. All components and links from the source are copied into the new project, which gets its own independent blueprint — subsequent changes to either project do not affect the other.
+
+Environments are not cloned; create them separately with `mass environment create` (or `mass environment fork`).
+
+## Usage
+
+```bash
+mass project clone <source-project> <new-id> [flags]
+```
+
+- `<source-project>` is the project ID/slug to clone from.
+- `<new-id>` is the new project's short, memorable identifier (max 20 chars, lowercase alphanumeric). Immutable after creation.
+
+## Flags
+
+- `--name, -n`: New project name (defaults to `<new-id>` if not provided)
+- `--description, -d`: Optional project description
+- `--attributes, -a`: Custom attributes for ABAC (e.g. `-a team=ops,system=api`)
+
+## Examples
+
+```bash
+# Clone the ecomm blueprint into a new project
+mass project clone ecomm ecomm-copy
+
+# Clone with a custom display name and attributes
+mass project clone ecomm ecomm-eu -n "Ecomm (EU)" -a region=eu
+```
+
+
+```
+mass project clone [source-project] [new-id] [flags]
+```
+
+### Examples
+
+```
+mass project clone ecomm ecomm-copy
+```
+
+### Options
+
+```
+  -a, --attributes stringToString   Custom attributes for ABAC (e.g. -a team=ops,system=api) (default [])
+  -d, --description string          Optional project description
+  -h, --help                        help for clone
+  -n, --name string                 New project name (defaults to new-id if not provided)
+```
+
+### SEE ALSO
+
+* [mass project](/cli/commands/mass_project)	 - Project management

--- a/docs/generated/mass_project_list.md
+++ b/docs/generated/mass_project_list.md
@@ -36,7 +36,9 @@ mass project list [flags]
 
 ```
   -h, --help            help for list
+      --name string     Filter to projects whose name exactly matches
   -o, --output string   Output format (table, json) (default "table")
+      --search string   Free-text search across project name and description
 ```
 
 ### SEE ALSO

--- a/docs/generated/mass_project_list.md
+++ b/docs/generated/mass_project_list.md
@@ -17,14 +17,29 @@ Lists all Massdriver projects in your organization.
 ## Usage
 
 ```bash
-mass project list
+mass project list [flags]
 ```
+
+## Flags
+
+- `--output, -o`: Output format, `table` (default) or `json`
+- `--name`: Filter to projects whose name exactly matches the given value
+- `--search`: Free-text search across the project's name and description (matches whole words anywhere; results are ranked by relevance)
 
 ## Examples
 
 ```bash
 # List all projects
 mass project list
+
+# Filter to a project by exact name
+mass project list --name "Ecommerce"
+
+# Free-text search across name and description
+mass project list --search ecomm
+
+# JSON output
+mass project list -o json
 ```
 
 

--- a/docs/helpdocs/deployment/compare.md
+++ b/docs/helpdocs/deployment/compare.md
@@ -1,0 +1,31 @@
+# Compare Deployments
+
+Diffs two deployments' snapshotted configuration: the bundle version on each side plus a flat, leaf-level diff of the params.
+
+Use it to audit what a deploy changed ("what did this deployment do to the params?") or to contrast deploys from different points in time. Runtime state, logs, and produced artifacts are out of scope.
+
+The two deployments need not target the same instance, though comparing unrelated instances naturally reports every param as present on one side only.
+
+## Usage
+
+```bash
+mass deployment compare <source-deployment-id> <target-deployment-id> [flags]
+```
+
+## Flags
+
+- `--output, -o`: Output format, `text` (default) or `json`
+- `--all`: Show unchanged params too (by default only differing params are shown)
+
+## Examples
+
+```bash
+# Show only the params that changed between two deployments
+mass deployment compare 1111... 2222...
+
+# Show every param, changed or not
+mass deployment compare 1111... 2222... --all
+
+# Machine-readable output
+mass deployment compare 1111... 2222... -o json
+```

--- a/docs/helpdocs/environment/compare.md
+++ b/docs/helpdocs/environment/compare.md
@@ -1,0 +1,31 @@
+# Compare Environments
+
+Performs a side-by-side comparison of two environments in the same project, instance-by-instance.
+
+Instances are paired across environments by their underlying component. For each pair the comparison reports the bundle version diff and a flat, leaf-level diff of the params. When only one environment has an instance for a component, it is reported as present on that side only.
+
+Environment-level attributes and default resource wiring are out of scope.
+
+## Usage
+
+```bash
+mass environment compare <source-environment> <target-environment> [flags]
+```
+
+## Flags
+
+- `--output, -o`: Output format, `text` (default) or `json`
+- `--all`: Show unchanged params and matching instances too (by default only differences are shown)
+
+## Examples
+
+```bash
+# Show what differs between staging and production
+mass environment compare ecomm-staging ecomm-production
+
+# Include matching instances and unchanged params
+mass environment compare ecomm-staging ecomm-production --all
+
+# Machine-readable output
+mass environment compare ecomm-staging ecomm-production -o json
+```

--- a/docs/helpdocs/instance/remote-reference-remove.md
+++ b/docs/helpdocs/instance/remote-reference-remove.md
@@ -1,0 +1,19 @@
+# Remove an Instance Remote Reference
+
+Removes a per-instance connection slot override, reverting the slot to the blueprint Link's wiring (or the environment default).
+
+Like other configuration changes, the instance must not be in PROVISIONED or FAILED status.
+
+## Usage
+
+```bash
+mass instance remote-reference remove <instance-id> <field>
+```
+
+Where `<field>` is the connection slot key whose override should be removed.
+
+## Examples
+
+```bash
+mass instance remote-reference remove ecomm-prod-api database
+```

--- a/docs/helpdocs/instance/remote-reference-set.md
+++ b/docs/helpdocs/instance/remote-reference-set.md
@@ -1,0 +1,26 @@
+# Set an Instance Remote Reference
+
+Overrides one of an instance's connection slots with a resource from another project (or an imported resource).
+
+The override takes priority over any blueprint-level Link wired into the same slot, and reverts to the Link (or environment default) when removed with `mass instance remote-reference remove`.
+
+Like other configuration changes, the instance must not be in PROVISIONED or FAILED status.
+
+## Usage
+
+```bash
+mass instance remote-reference set <instance-id> <field> <resource-id>
+```
+
+- `<field>` is the key in the instance's bundle `connectionsSchema` to bind.
+- `<resource-id>` is either a UUID (for imported resources) or `instance.field` (for provisioned resources).
+
+## Examples
+
+```bash
+# Point the "database" connection slot at a resource produced by another instance
+mass instance remote-reference set ecomm-prod-api database ecomm-prod-db.postgres
+
+# Point a slot at an imported resource by UUID
+mass instance remote-reference set ecomm-prod-api database 12345678-1234-1234-1234-123456789012
+```

--- a/docs/helpdocs/instance/remote-reference.md
+++ b/docs/helpdocs/instance/remote-reference.md
@@ -1,0 +1,12 @@
+# Instance Remote References
+
+A remote reference is a per-instance override of a single connection slot, pointing the slot at a resource from another project (or an imported resource) instead of the blueprint Link's wiring.
+
+The override takes priority over any blueprint-level Link wired into the same slot, and reverts to the Link (or environment default) when removed.
+
+## Subcommands
+
+- `set` — override a connection slot with a specific resource
+- `remove` — remove the override, reverting to the blueprint wiring
+
+See `mass instance remote-reference set --help` and `mass instance remote-reference remove --help` for details.

--- a/docs/helpdocs/instance/rollback.md
+++ b/docs/helpdocs/instance/rollback.md
@@ -1,0 +1,23 @@
+# Roll an Instance Back
+
+Proposes a return to a past deployment's exact state. Given a historical deployment — which must be a COMPLETED PROVISION — this creates a new PROPOSED PROVISION deployment that snapshots the source deployment's params, connection wiring, bundle version, and release.
+
+The returned proposal goes through the normal review flow: approve it with `mass deployment approve`, discard it with `mass deployment reject`, or preview it with `mass instance plan`. On approval, the instance is pinned to the source deployment's exact bundle version, params, and connection snapshot — overriding whatever release is currently configured.
+
+## Usage
+
+```bash
+mass instance rollback <deployment-id>
+```
+
+Where `<deployment-id>` is the historical COMPLETED PROVISION deployment to return to.
+
+## Examples
+
+```bash
+# Propose rolling back to a known-good past deployment
+mass instance rollback 12345678-1234-1234-1234-123456789012
+
+# Then approve it to apply
+mass deployment approve <proposed-deployment-id>
+```

--- a/docs/helpdocs/instance/rollback.md
+++ b/docs/helpdocs/instance/rollback.md
@@ -2,7 +2,7 @@
 
 Proposes a return to a past deployment's exact state. Given a historical deployment — which must be a COMPLETED PROVISION — this creates a new PROPOSED PROVISION deployment that snapshots the source deployment's params, connection wiring, bundle version, and release.
 
-The returned proposal goes through the normal review flow: approve it with `mass deployment approve`, discard it with `mass deployment reject`, or preview it with `mass instance plan`. On approval, the instance is pinned to the source deployment's exact bundle version, params, and connection snapshot — overriding whatever release is currently configured.
+The returned proposal goes through the normal review flow: approve it with `mass deployment approve` or discard it with `mass deployment reject`. On approval, the instance is pinned to the source deployment's exact bundle version, params, and connection snapshot — overriding whatever release is currently configured.
 
 ## Usage
 

--- a/docs/helpdocs/project/clone.md
+++ b/docs/helpdocs/project/clone.md
@@ -1,0 +1,30 @@
+# Clone Project
+
+Creates a new project by copying another project's blueprint. All components and links from the source are copied into the new project, which gets its own independent blueprint — subsequent changes to either project do not affect the other.
+
+Environments are not cloned; create them separately with `mass environment create` (or `mass environment fork`).
+
+## Usage
+
+```bash
+mass project clone <source-project> <new-id> [flags]
+```
+
+- `<source-project>` is the project ID/slug to clone from.
+- `<new-id>` is the new project's short, memorable identifier (max 20 chars, lowercase alphanumeric). Immutable after creation.
+
+## Flags
+
+- `--name, -n`: New project name (defaults to `<new-id>` if not provided)
+- `--description, -d`: Optional project description
+- `--attributes, -a`: Custom attributes for ABAC (e.g. `-a team=ops,system=api`)
+
+## Examples
+
+```bash
+# Clone the ecomm blueprint into a new project
+mass project clone ecomm ecomm-copy
+
+# Clone with a custom display name and attributes
+mass project clone ecomm ecomm-eu -n "Ecomm (EU)" -a region=eu
+```

--- a/docs/helpdocs/project/list.md
+++ b/docs/helpdocs/project/list.md
@@ -5,12 +5,27 @@ Lists all Massdriver projects in your organization.
 ## Usage
 
 ```bash
-mass project list
+mass project list [flags]
 ```
+
+## Flags
+
+- `--output, -o`: Output format, `table` (default) or `json`
+- `--name`: Filter to projects whose name exactly matches the given value
+- `--search`: Free-text search across the project's name and description (matches whole words anywhere; results are ranked by relevance)
 
 ## Examples
 
 ```bash
 # List all projects
 mass project list
+
+# Filter to a project by exact name
+mass project list --name "Ecommerce"
+
+# Free-text search across name and description
+mass project list --search ecomm
+
+# JSON output
+mass project list -o json
 ```

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/itchyny/gojq v0.12.16
 	github.com/manifoldco/promptui v0.9.0
 	github.com/massdriver-cloud/airlock v0.0.10
-	github.com/massdriver-cloud/massdriver-sdk-go v0.2.6
+	github.com/massdriver-cloud/massdriver-sdk-go v0.2.10-0.20260721201746-c925c95365f7
 	github.com/mattn/go-runewidth v0.0.24
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/osteele/liquid v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/itchyny/gojq v0.12.16
 	github.com/manifoldco/promptui v0.9.0
 	github.com/massdriver-cloud/airlock v0.0.10
-	github.com/massdriver-cloud/massdriver-sdk-go v0.2.10-0.20260721201746-c925c95365f7
+	github.com/massdriver-cloud/massdriver-sdk-go v0.2.10
 	github.com/mattn/go-runewidth v0.0.24
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/osteele/liquid v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -145,6 +145,8 @@ github.com/massdriver-cloud/massdriver-sdk-go v0.2.6 h1:si8MxuvRBTK3cz6IsAaXvtjE
 github.com/massdriver-cloud/massdriver-sdk-go v0.2.6/go.mod h1:6NrSP+wfGQvUOAggsz10/Wkln8CKmk3VBnD+OJzZgFY=
 github.com/massdriver-cloud/massdriver-sdk-go v0.2.10-0.20260721201746-c925c95365f7 h1:6shd1AfMSiLwfRf5w4NJIQZLzRG+Zsd8Pex/VpnC94Q=
 github.com/massdriver-cloud/massdriver-sdk-go v0.2.10-0.20260721201746-c925c95365f7/go.mod h1:6NrSP+wfGQvUOAggsz10/Wkln8CKmk3VBnD+OJzZgFY=
+github.com/massdriver-cloud/massdriver-sdk-go v0.2.10 h1:KtRWFibrabU5shvIiIQMpYieg72gUq93omM39LuEPTw=
+github.com/massdriver-cloud/massdriver-sdk-go v0.2.10/go.mod h1:6NrSP+wfGQvUOAggsz10/Wkln8CKmk3VBnD+OJzZgFY=
 github.com/massdriver-cloud/terraform-config-inspect v0.0.2 h1:Jc7BrhFHLbK7Epig6ShiEVMzQPPHVIOx0/BatvtEwtY=
 github.com/massdriver-cloud/terraform-config-inspect v0.0.2/go.mod h1:3AbDpWxIRMdMAg7FDmTJuVBhCGNwdm49cBIOmUHjqRg=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=

--- a/go.sum
+++ b/go.sum
@@ -143,6 +143,8 @@ github.com/massdriver-cloud/airlock v0.0.10 h1:05wz7kovH09X1VMfHcjLWylYanoLFcxuD
 github.com/massdriver-cloud/airlock v0.0.10/go.mod h1:igJm33JvINiUtbyEspUeKUWyWewG+jYyxO1UDHqLp9Q=
 github.com/massdriver-cloud/massdriver-sdk-go v0.2.6 h1:si8MxuvRBTK3cz6IsAaXvtjE8jsxUnL0Q7O4vixAkxw=
 github.com/massdriver-cloud/massdriver-sdk-go v0.2.6/go.mod h1:6NrSP+wfGQvUOAggsz10/Wkln8CKmk3VBnD+OJzZgFY=
+github.com/massdriver-cloud/massdriver-sdk-go v0.2.10-0.20260721201746-c925c95365f7 h1:6shd1AfMSiLwfRf5w4NJIQZLzRG+Zsd8Pex/VpnC94Q=
+github.com/massdriver-cloud/massdriver-sdk-go v0.2.10-0.20260721201746-c925c95365f7/go.mod h1:6NrSP+wfGQvUOAggsz10/Wkln8CKmk3VBnD+OJzZgFY=
 github.com/massdriver-cloud/terraform-config-inspect v0.0.2 h1:Jc7BrhFHLbK7Epig6ShiEVMzQPPHVIOx0/BatvtEwtY=
 github.com/massdriver-cloud/terraform-config-inspect v0.0.2/go.mod h1:3AbDpWxIRMdMAg7FDmTJuVBhCGNwdm49cBIOmUHjqRg=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=


### PR DESCRIPTION
## Summary

Surfaces new functionality from massdriver-sdk-go PR #34 (v0.2.10) in the CLI. Each command is a thin wrapper over a newly-added public SDK method, following the existing command patterns (cobra builders, `-o text|json` where it applies, embedded helpdocs, generated reference docs).

## New commands

| Command | SDK method | Description |
|---|---|---|
| `mass deployment compare <src> <tgt>` | `Deployments.Compare` | Bundle-version + leaf-level param diff between two deployments |
| `mass environment compare <src> <tgt>` | `Environments.Compare` | Instance-by-instance diff of two environments |
| `mass instance rollback <deployment-id>` | `Deployments.Rollback` | Propose returning an instance to a past COMPLETED deployment (goes through the normal approve/reject flow) |
| `mass instance remote-reference set <instance> <field> <resource-id>` | `Instances.SetRemoteReference` | Override a connection slot with a resource from another project |
| `mass instance remote-reference remove <instance> <field>` | `Instances.RemoveRemoteReference` | Remove the override, reverting to blueprint wiring |
| `mass project clone <src> <new-id>` | `Projects.Clone` | Clone a project's blueprint into a new project (mirrors `env fork`) |

## Enhancements

- `mass project list` gains `--name` (exact match) and `--search` (free-text) filters, backed by the new `projects.ListInput` fields.

## Both `compare` commands

- Print a version diff plus a table of leaf-level param changes; only differences are shown by default, `--all` includes unchanged entries.
- Support `-o json` for the full structured comparison.
- Share rendering helpers in `cmd/compare.go`.

## Refactor

- Extracted `streamDeploymentLogs` from `deployment logs` so log-tailing (with the no-PAT static-log fallback) can be reused.

## Notes / out of scope

- **`mass instance plan` was intentionally not added.** `Deployments.Plan` overlaps with the existing `instance deploy --plan`; its only distinct use case (previewing a proposal pre-approval) isn't requested yet and would be better placed as `mass deployment plan` if it ever is.
- **Grants not included.** The SDK PR also adds resource grant *listing* and a full OCI-repo grants feature; the CLI exposes no grant commands today, so that's deferred to its own PR (larger new subcommand tree).
