### PR TITLE
Support 'resource-type' as a valid OCI repo artifact type

### DIFF
--- a/cmd/repository.go
+++ b/cmd/repository.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/charmbracelet/glamour"
 	"github.com/massdriver-cloud/mass/internal/cli"
+	cmdrepository "github.com/massdriver-cloud/mass/internal/commands/repository"
 	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver"
 	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/platform/ocirepos"
 	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/platform/types"
@@ -24,24 +25,12 @@ import (
 //go:embed templates/repository.get.md.tmpl
 var repositoryTemplates embed.FS
 
-// artifactTypeAliases maps the user-facing --type flag values to the SDK's
-// typed artifact-type enum. Today only "bundle" is supported by the platform.
-var artifactTypeAliases = map[string]ocirepos.ArtifactType{
-	"bundle": ocirepos.ArtifactTypeBundle,
-}
-
-// artifactTypeLabels is the reverse lookup for table/output rendering — turns
-// the SDK's typed enum back into the friendly name the user typed.
-var artifactTypeLabels = map[ocirepos.ArtifactType]string{
-	ocirepos.ArtifactTypeBundle: "bundle",
-}
-
 // NewCmdRepository returns a cobra command for managing OCI repositories.
 func NewCmdRepository() *cobra.Command {
 	repositoryCmd := &cobra.Command{
 		Use:     "repository",
 		Aliases: []string{"repo"},
-		Short:   "Manage OCI repositories (bundles and, in future, resource types and provisioners)",
+		Short:   "Manage OCI repositories (bundles and resource types)",
 	}
 
 	listInput := repositoryListInput{}
@@ -57,7 +46,7 @@ func NewCmdRepository() *cobra.Command {
 	repositoryListCmd.Flags().StringVarP(&listInput.name, "name", "n", "", "Filter by exact repository name")
 	repositoryListCmd.Flags().StringVar(&listInput.prefix, "prefix", "", "Filter by repository name prefix")
 	repositoryListCmd.Flags().StringVarP(&listInput.search, "search", "s", "", "Full-text search across name, readme, and changelog")
-	repositoryListCmd.Flags().StringVarP(&listInput.kind, "type", "t", "", "Filter by artifact type (bundle)")
+	repositoryListCmd.Flags().StringVarP(&listInput.kind, "type", "t", "", "Filter by artifact type (bundle, resource-type)")
 	repositoryListCmd.Flags().StringVar(&listInput.sortField, "sort", "", "Sort field (name, created_at)")
 	repositoryListCmd.Flags().StringVar(&listInput.sortOrder, "order", "asc", "Sort order (asc, desc)")
 	repositoryListCmd.Flags().StringVarP(&listInput.output, "output", "o", "table", "Output format (table, json)")
@@ -77,7 +66,7 @@ func NewCmdRepository() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE:  runRepositoryCreate,
 	}
-	repositoryCreateCmd.Flags().StringP("type", "t", "", "Artifact type (bundle)")
+	repositoryCreateCmd.Flags().StringP("type", "t", "", "Artifact type (bundle, resource-type)")
 	repositoryCreateCmd.Flags().StringToStringP("attributes", "a", nil, "Custom attributes (e.g. -a owner=data,service=database)")
 	_ = repositoryCreateCmd.MarkFlagRequired("type")
 
@@ -150,7 +139,7 @@ func runRepositoryList(input *repositoryListInput, orderChanged bool) error {
 		return cli.Paginate(seq, cli.PagerConfig[ocirepos.OciRepo]{
 			Columns: []string{"Name", "Type", "Latest", "Created At"},
 			Row: func(repo ocirepos.OciRepo) []string {
-				return []string{repo.Name, artifactTypeLabel(repo.ArtifactType), repo.LatestTag, repo.CreatedAt.Format("2006-01-02 15:04:05")}
+				return []string{repo.Name, cmdrepository.ArtifactTypeLabel(repo.ArtifactType), repo.LatestTag, repo.CreatedAt.Format("2006-01-02 15:04:05")}
 			},
 		})
 	default:
@@ -166,7 +155,7 @@ func buildOciReposListInput(input *repositoryListInput, orderChanged bool) (ocir
 	}
 
 	if input.kind != "" {
-		artifactType, resolveErr := resolveArtifactType(input.kind)
+		artifactType, resolveErr := cmdrepository.ResolveArtifactType(input.kind)
 		if resolveErr != nil {
 			return out, resolveErr
 		}
@@ -218,20 +207,6 @@ func parseRepoSortOrder(s string) (ocirepos.SortOrder, error) {
 	default:
 		return "", fmt.Errorf("unknown sort order %q (valid: asc, desc)", s)
 	}
-}
-
-func resolveArtifactType(s string) (ocirepos.ArtifactType, error) {
-	if at, ok := artifactTypeAliases[strings.ToLower(s)]; ok {
-		return at, nil
-	}
-	return "", fmt.Errorf("unknown artifact type %q (valid: bundle)", s)
-}
-
-func artifactTypeLabel(at ocirepos.ArtifactType) string {
-	if label, ok := artifactTypeLabels[at]; ok {
-		return label
-	}
-	return string(at)
 }
 
 func runRepositoryGet(cmd *cobra.Command, args []string) error {
@@ -300,7 +275,7 @@ func renderRepository(repo *ocirepos.OciRepo, tagCount int) error {
 		FormatTime func(time.Time) string
 	}{
 		OciRepo:    repo,
-		TypeLabel:  artifactTypeLabel(repo.ArtifactType),
+		TypeLabel:  cmdrepository.ArtifactTypeLabel(repo.ArtifactType),
 		ShownTags:  tags,
 		TotalTags:  len(repo.Tags),
 		Truncated:  tagCount > 0 && len(repo.Tags) > tagCount,
@@ -351,13 +326,9 @@ func runRepositoryCreate(cmd *cobra.Command, args []string) error {
 // `mass bundle create`. It resolves the friendly type name into the
 // ArtifactType enum, calls the SDK, and prints a success line.
 func createOciRepoCommon(ctx context.Context, mdClient *massdriver.Client, name, typeFlag string, attrs map[string]string) error {
-	artifactType, resolveErr := resolveArtifactType(typeFlag)
+	artifactType, resolveErr := cmdrepository.ResolveArtifactType(typeFlag)
 	if resolveErr != nil {
-		valid := make([]string, 0, len(artifactTypeAliases))
-		for k := range artifactTypeAliases {
-			valid = append(valid, k)
-		}
-		return fmt.Errorf("unknown artifact type %q (valid: %s)", typeFlag, strings.Join(valid, ", "))
+		return resolveErr
 	}
 
 	created, err := mdClient.OciRepos.Create(ctx, ocirepos.CreateInput{
@@ -369,7 +340,7 @@ func createOciRepoCommon(ctx context.Context, mdClient *massdriver.Client, name,
 		return err
 	}
 
-	fmt.Printf("✅ Repository `%s` created (type: %s)\n", created.Name, artifactTypeLabel(created.ArtifactType))
+	fmt.Printf("✅ Repository `%s` created (type: %s)\n", created.Name, cmdrepository.ArtifactTypeLabel(created.ArtifactType))
 	return nil
 }
 

--- a/docs/generated/mass.md
+++ b/docs/generated/mass.md
@@ -40,7 +40,7 @@ Configure and deploying infrastructure and applications.
 * [mass environment](/cli/commands/mass_environment)	 - Environment management
 * [mass instance](/cli/commands/mass_instance)	 - Manage instances of IaC deployed in environments.
 * [mass project](/cli/commands/mass_project)	 - Project management
-* [mass repository](/cli/commands/mass_repository)	 - Manage OCI repositories (bundles and, in future, resource types and provisioners)
+* [mass repository](/cli/commands/mass_repository)	 - Manage OCI repositories (bundles and resource types)
 * [mass resource](/cli/commands/mass_resource)	 - Manage resources
 * [mass resource-type](/cli/commands/mass_resource-type)	 - Resource type management
 * [mass schema](/cli/commands/mass_schema)	 - Manage JSON Schemas

--- a/docs/generated/mass_repository.md
+++ b/docs/generated/mass_repository.md
@@ -6,7 +6,7 @@ sidebar_label: Mass Repository
 ---
 ## mass repository
 
-Manage OCI repositories (bundles and, in future, resource types and provisioners)
+Manage OCI repositories (bundles and resource types)
 
 ### Options
 

--- a/docs/generated/mass_repository_create.md
+++ b/docs/generated/mass_repository_create.md
@@ -17,9 +17,9 @@ mass repository create <name> [flags]
 ```
   -a, --attributes stringToString   Custom attributes (e.g. -a owner=data,service=database) (default [])
   -h, --help                        help for create
-  -t, --type string                 Artifact type (bundle)
+  -t, --type string                 Artifact type (bundle, resource-type)
 ```
 
 ### SEE ALSO
 
-* [mass repository](/cli/commands/mass_repository)	 - Manage OCI repositories (bundles and, in future, resource types and provisioners)
+* [mass repository](/cli/commands/mass_repository)	 - Manage OCI repositories (bundles and resource types)

--- a/docs/generated/mass_repository_delete.md
+++ b/docs/generated/mass_repository_delete.md
@@ -21,4 +21,4 @@ mass repository delete <name> [flags]
 
 ### SEE ALSO
 
-* [mass repository](/cli/commands/mass_repository)	 - Manage OCI repositories (bundles and, in future, resource types and provisioners)
+* [mass repository](/cli/commands/mass_repository)	 - Manage OCI repositories (bundles and resource types)

--- a/docs/generated/mass_repository_get.md
+++ b/docs/generated/mass_repository_get.md
@@ -22,4 +22,4 @@ mass repository get <name> [flags]
 
 ### SEE ALSO
 
-* [mass repository](/cli/commands/mass_repository)	 - Manage OCI repositories (bundles and, in future, resource types and provisioners)
+* [mass repository](/cli/commands/mass_repository)	 - Manage OCI repositories (bundles and resource types)

--- a/docs/generated/mass_repository_list.md
+++ b/docs/generated/mass_repository_list.md
@@ -22,9 +22,9 @@ mass repository list [flags]
       --prefix string   Filter by repository name prefix
   -s, --search string   Full-text search across name, readme, and changelog
       --sort string     Sort field (name, created_at)
-  -t, --type string     Filter by artifact type (bundle)
+  -t, --type string     Filter by artifact type (bundle, resource-type)
 ```
 
 ### SEE ALSO
 
-* [mass repository](/cli/commands/mass_repository)	 - Manage OCI repositories (bundles and, in future, resource types and provisioners)
+* [mass repository](/cli/commands/mass_repository)	 - Manage OCI repositories (bundles and resource types)

--- a/docs/generated/mass_repository_update.md
+++ b/docs/generated/mass_repository_update.md
@@ -21,4 +21,4 @@ mass repository update <name> [flags]
 
 ### SEE ALSO
 
-* [mass repository](/cli/commands/mass_repository)	 - Manage OCI repositories (bundles and, in future, resource types and provisioners)
+* [mass repository](/cli/commands/mass_repository)	 - Manage OCI repositories (bundles and resource types)

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/itchyny/gojq v0.12.16
 	github.com/manifoldco/promptui v0.9.0
 	github.com/massdriver-cloud/airlock v0.0.10
-	github.com/massdriver-cloud/massdriver-sdk-go v0.2.10
+	github.com/massdriver-cloud/massdriver-sdk-go v0.2.11
 	github.com/mattn/go-runewidth v0.0.24
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/osteele/liquid v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -147,6 +147,8 @@ github.com/massdriver-cloud/massdriver-sdk-go v0.2.10-0.20260721201746-c925c9536
 github.com/massdriver-cloud/massdriver-sdk-go v0.2.10-0.20260721201746-c925c95365f7/go.mod h1:6NrSP+wfGQvUOAggsz10/Wkln8CKmk3VBnD+OJzZgFY=
 github.com/massdriver-cloud/massdriver-sdk-go v0.2.10 h1:KtRWFibrabU5shvIiIQMpYieg72gUq93omM39LuEPTw=
 github.com/massdriver-cloud/massdriver-sdk-go v0.2.10/go.mod h1:6NrSP+wfGQvUOAggsz10/Wkln8CKmk3VBnD+OJzZgFY=
+github.com/massdriver-cloud/massdriver-sdk-go v0.2.11 h1:8MXqxArkX3TO+UJpzRF7iexHVO08TocPDqGGk6twBeM=
+github.com/massdriver-cloud/massdriver-sdk-go v0.2.11/go.mod h1:6NrSP+wfGQvUOAggsz10/Wkln8CKmk3VBnD+OJzZgFY=
 github.com/massdriver-cloud/terraform-config-inspect v0.0.2 h1:Jc7BrhFHLbK7Epig6ShiEVMzQPPHVIOx0/BatvtEwtY=
 github.com/massdriver-cloud/terraform-config-inspect v0.0.2/go.mod h1:3AbDpWxIRMdMAg7FDmTJuVBhCGNwdm49cBIOmUHjqRg=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=

--- a/internal/commands/repository/artifacttype.go
+++ b/internal/commands/repository/artifacttype.go
@@ -1,0 +1,55 @@
+// Package repository holds the testable logic behind the `mass repository`
+// CLI commands. The cobra wiring lives in the top-level cmd package; anything
+// worth a unit test belongs here.
+package repository
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/platform/ocirepos"
+)
+
+// artifactTypeAliases maps the user-facing --type flag values to the SDK's
+// typed artifact-type enum.
+var artifactTypeAliases = map[string]ocirepos.ArtifactType{
+	"bundle":        ocirepos.ArtifactTypeBundle,
+	"resource-type": ocirepos.ArtifactTypeResourceType,
+}
+
+// artifactTypeLabels is the reverse lookup for table/output rendering — turns
+// the SDK's typed enum back into the friendly name the user typed.
+var artifactTypeLabels = map[ocirepos.ArtifactType]string{
+	ocirepos.ArtifactTypeBundle:       "bundle",
+	ocirepos.ArtifactTypeResourceType: "resource-type",
+}
+
+// ResolveArtifactType converts a user-facing alias (e.g. "bundle",
+// "resource-type") into the SDK's typed enum. Matching is case-insensitive.
+func ResolveArtifactType(s string) (ocirepos.ArtifactType, error) {
+	if at, ok := artifactTypeAliases[strings.ToLower(s)]; ok {
+		return at, nil
+	}
+	return "", fmt.Errorf("unknown artifact type %q (valid: %s)", s, strings.Join(ValidArtifactTypes(), ", "))
+}
+
+// ArtifactTypeLabel renders an enum value back to its friendly alias, falling
+// back to the raw enum string for values without a known label.
+func ArtifactTypeLabel(at ocirepos.ArtifactType) string {
+	if label, ok := artifactTypeLabels[at]; ok {
+		return label
+	}
+	return string(at)
+}
+
+// ValidArtifactTypes returns the user-facing artifact-type aliases in a
+// deterministic (sorted) order, for flag help and error messages.
+func ValidArtifactTypes() []string {
+	valid := make([]string, 0, len(artifactTypeAliases))
+	for k := range artifactTypeAliases {
+		valid = append(valid, k)
+	}
+	sort.Strings(valid)
+	return valid
+}

--- a/internal/commands/repository/artifacttype_test.go
+++ b/internal/commands/repository/artifacttype_test.go
@@ -1,0 +1,66 @@
+package repository_test
+
+import (
+	"testing"
+
+	"github.com/massdriver-cloud/mass/internal/commands/repository"
+	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/platform/ocirepos"
+)
+
+// TestArtifactTypeRoundTrip verifies that every user-facing alias resolves to
+// an enum and renders back to the same friendly label, for both supported
+// artifact types.
+func TestArtifactTypeRoundTrip(t *testing.T) {
+	cases := []struct {
+		alias string
+		enum  ocirepos.ArtifactType
+	}{
+		{"bundle", ocirepos.ArtifactTypeBundle},
+		{"resource-type", ocirepos.ArtifactTypeResourceType},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.alias, func(t *testing.T) {
+			at, err := repository.ResolveArtifactType(tc.alias)
+			if err != nil {
+				t.Fatalf("ResolveArtifactType(%q) returned error: %v", tc.alias, err)
+			}
+			if at != tc.enum {
+				t.Errorf("ResolveArtifactType(%q) = %q, want %q", tc.alias, at, tc.enum)
+			}
+			if label := repository.ArtifactTypeLabel(at); label != tc.alias {
+				t.Errorf("ArtifactTypeLabel(%q) = %q, want %q", at, label, tc.alias)
+			}
+		})
+	}
+}
+
+func TestResolveArtifactTypeCaseInsensitive(t *testing.T) {
+	at, err := repository.ResolveArtifactType("Resource-Type")
+	if err != nil {
+		t.Fatalf("ResolveArtifactType returned error: %v", err)
+	}
+	if at != ocirepos.ArtifactTypeResourceType {
+		t.Errorf("ResolveArtifactType(%q) = %q, want %q", "Resource-Type", at, ocirepos.ArtifactTypeResourceType)
+	}
+}
+
+func TestResolveArtifactTypeUnknown(t *testing.T) {
+	_, err := repository.ResolveArtifactType("provisioner")
+	if err == nil {
+		t.Fatal("expected error for unknown artifact type, got nil")
+	}
+	// The error should enumerate the valid types in sorted order.
+	want := "unknown artifact type \"provisioner\" (valid: bundle, resource-type)"
+	if err.Error() != want {
+		t.Errorf("error = %q, want %q", err.Error(), want)
+	}
+}
+
+// TestArtifactTypeLabelFallback ensures an unmapped enum value renders as its
+// raw string rather than an empty label.
+func TestArtifactTypeLabelFallback(t *testing.T) {
+	if got := repository.ArtifactTypeLabel(ocirepos.ArtifactType("SOMETHING_NEW")); got != "SOMETHING_NEW" {
+		t.Errorf("ArtifactTypeLabel fallback = %q, want %q", got, "SOMETHING_NEW")
+	}
+}


### PR DESCRIPTION
Wires the `RESOURCE_TYPE` artifact type (added in massdriver-sdk-go v0.2.11) through the `mass repository` commands, which previously assumed bundles were the only artifact type.

### Changes

- **SDK bump** to `v0.2.11`, which exposes `ArtifactTypeResourceType`.
- **`--type resource-type`** now resolves on `mass repository create` and `mass repository list --type`.
- **Output rendering** — resource-type repos now render with the friendly `resource-type` label in `list` and `get` output instead of the raw `RESOURCE_TYPE` enum.
- **Help & error text** — flag help now reads `(bundle, resource-type)`, and the "unknown artifact type" error enumerates valid types in a deterministic (sorted) order via a single shared helper (previously duplicated with nondeterministic ordering).

### Refactor

- Extracted the artifact-type resolution/label logic out of `cmd/repository.go` into a new `internal/commands/repository` package (`ResolveArtifactType`, `ArtifactTypeLabel`, `ValidArtifactTypes`), matching the convention where `cmd/` only wires cobra and testable logic lives under `internal/commands`.

### Tests

- Added `internal/commands/repository/artifacttype_test.go` covering alias↔enum round-tripping for both types, case-insensitive resolution, the sorted unknown-type error message, and the raw-string label fallback for unmapped enums.

### Notes

- `mass bundle create` is unaffected — it hardcodes `ArtifactTypeBundle` and shares the same create path.