### PR TITLE
Use pointer semantics for entity update inputs (SDK v0.2.15)

### DIFF
--- a/cmd/component.go
+++ b/cmd/component.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/massdriver-cloud/mass/docs/helpdocs"
@@ -160,7 +161,7 @@ func runComponentUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	if !cmd.Flags().Changed("name") && !cmd.Flags().Changed("description") && !cmd.Flags().Changed("attributes") {
-		return fmt.Errorf("nothing to update: set at least one of --name, --description, or --attributes")
+		return errors.New("nothing to update: set at least one of --name, --description, or --attributes")
 	}
 
 	// Only send fields whose flags were explicitly set. Nil pointers (and a

--- a/cmd/component.go
+++ b/cmd/component.go
@@ -159,28 +159,21 @@ func runComponentUpdate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("error initializing massdriver client: %w", err)
 	}
 
-	current, err := mdClient.Components.Get(ctx, componentID)
-	if err != nil {
-		return fmt.Errorf("error getting component: %w", err)
+	if !cmd.Flags().Changed("name") && !cmd.Flags().Changed("description") && !cmd.Flags().Changed("attributes") {
+		return fmt.Errorf("nothing to update: set at least one of --name, --description, or --attributes")
 	}
 
-	if !cmd.Flags().Changed("name") {
-		name = current.Name
+	// Only send fields whose flags were explicitly set. Nil pointers (and a
+	// nil Attributes map) leave the corresponding values unchanged at the server.
+	input := components.UpdateInput{}
+	if cmd.Flags().Changed("name") {
+		input.Name = &name
 	}
-	if !cmd.Flags().Changed("description") {
-		description = current.Description
+	if cmd.Flags().Changed("description") {
+		input.Description = &description
 	}
-	var attributes map[string]any
 	if cmd.Flags().Changed("attributes") {
-		attributes = cli.AttributesToAnyMap(attrs)
-	} else {
-		attributes = current.Attributes
-	}
-
-	input := components.UpdateInput{
-		Name:        name,
-		Description: description,
-		Attributes:  attributes,
+		input.Attributes = cli.AttributesToAnyMap(attrs)
 	}
 
 	updated, err := mdClient.Components.Update(ctx, componentID, input)

--- a/cmd/environment.go
+++ b/cmd/environment.go
@@ -423,28 +423,21 @@ func runEnvironmentUpdate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("error initializing massdriver client: %w", err)
 	}
 
-	current, err := mdClient.Environments.Get(ctx, environmentID)
-	if err != nil {
-		return fmt.Errorf("error getting environment: %w", err)
+	if !cmd.Flags().Changed("name") && !cmd.Flags().Changed("description") && !cmd.Flags().Changed("attributes") {
+		return fmt.Errorf("nothing to update: set at least one of --name, --description, or --attributes")
 	}
 
-	if !cmd.Flags().Changed("name") {
-		name = current.Name
+	// Only send fields whose flags were explicitly set. Nil pointers (and a
+	// nil Attributes map) leave the corresponding values unchanged at the server.
+	input := environments.UpdateInput{}
+	if cmd.Flags().Changed("name") {
+		input.Name = &name
 	}
-	if !cmd.Flags().Changed("description") {
-		description = current.Description
+	if cmd.Flags().Changed("description") {
+		input.Description = &description
 	}
-	var attributes map[string]any
 	if cmd.Flags().Changed("attributes") {
-		attributes = cli.AttributesToAnyMap(attrs)
-	} else {
-		attributes = current.Attributes
-	}
-
-	input := environments.UpdateInput{
-		Name:        name,
-		Description: description,
-		Attributes:  attributes,
+		input.Attributes = cli.AttributesToAnyMap(attrs)
 	}
 
 	updated, err := mdClient.Environments.Update(ctx, environmentID, input)

--- a/cmd/environment.go
+++ b/cmd/environment.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -424,7 +425,7 @@ func runEnvironmentUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	if !cmd.Flags().Changed("name") && !cmd.Flags().Changed("description") && !cmd.Flags().Changed("attributes") {
-		return fmt.Errorf("nothing to update: set at least one of --name, --description, or --attributes")
+		return errors.New("nothing to update: set at least one of --name, --description, or --attributes")
 	}
 
 	// Only send fields whose flags were explicitly set. Nil pointers (and a

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -362,30 +362,21 @@ func runProjectUpdate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("error initializing massdriver client: %w", err)
 	}
 
-	// Fetch current state so unset flags retain their existing values rather
-	// than blanking the field at the server.
-	current, err := mdClient.Projects.Get(ctx, projectID)
-	if err != nil {
-		return fmt.Errorf("error getting project: %w", err)
+	if !cmd.Flags().Changed("name") && !cmd.Flags().Changed("description") && !cmd.Flags().Changed("attributes") {
+		return fmt.Errorf("nothing to update: set at least one of --name, --description, or --attributes")
 	}
 
-	if !cmd.Flags().Changed("name") {
-		name = current.Name
+	// Only send fields whose flags were explicitly set. Nil pointers (and a
+	// nil Attributes map) leave the corresponding values unchanged at the server.
+	input := projects.UpdateInput{}
+	if cmd.Flags().Changed("name") {
+		input.Name = &name
 	}
-	if !cmd.Flags().Changed("description") {
-		description = current.Description
+	if cmd.Flags().Changed("description") {
+		input.Description = &description
 	}
-	var attributes map[string]any
 	if cmd.Flags().Changed("attributes") {
-		attributes = cli.AttributesToAnyMap(attrs)
-	} else {
-		attributes = current.Attributes
-	}
-
-	input := projects.UpdateInput{
-		Name:        name,
-		Description: description,
-		Attributes:  attributes,
+		input.Attributes = cli.AttributesToAnyMap(attrs)
 	}
 
 	updated, err := mdClient.Projects.Update(ctx, projectID, input)

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -363,7 +364,7 @@ func runProjectUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	if !cmd.Flags().Changed("name") && !cmd.Flags().Changed("description") && !cmd.Flags().Changed("attributes") {
-		return fmt.Errorf("nothing to update: set at least one of --name, --description, or --attributes")
+		return errors.New("nothing to update: set at least one of --name, --description, or --attributes")
 	}
 
 	// Only send fields whose flags were explicitly set. Nil pointers (and a

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/itchyny/gojq v0.12.16
 	github.com/manifoldco/promptui v0.9.0
 	github.com/massdriver-cloud/airlock v0.0.10
-	github.com/massdriver-cloud/massdriver-sdk-go v0.2.11
+	github.com/massdriver-cloud/massdriver-sdk-go v0.2.15
 	github.com/mattn/go-runewidth v0.0.24
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/osteele/liquid v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -141,14 +141,8 @@ github.com/manifoldco/promptui v0.9.0 h1:3V4HzJk1TtXW1MTZMP7mdlwbBpIinw3HztaIlYt
 github.com/manifoldco/promptui v0.9.0/go.mod h1:ka04sppxSGFAtxX0qhlYQjISsg9mR4GWtQEhdbn6Pgg=
 github.com/massdriver-cloud/airlock v0.0.10 h1:05wz7kovH09X1VMfHcjLWylYanoLFcxuD0oZi13WG9U=
 github.com/massdriver-cloud/airlock v0.0.10/go.mod h1:igJm33JvINiUtbyEspUeKUWyWewG+jYyxO1UDHqLp9Q=
-github.com/massdriver-cloud/massdriver-sdk-go v0.2.6 h1:si8MxuvRBTK3cz6IsAaXvtjE8jsxUnL0Q7O4vixAkxw=
-github.com/massdriver-cloud/massdriver-sdk-go v0.2.6/go.mod h1:6NrSP+wfGQvUOAggsz10/Wkln8CKmk3VBnD+OJzZgFY=
-github.com/massdriver-cloud/massdriver-sdk-go v0.2.10-0.20260721201746-c925c95365f7 h1:6shd1AfMSiLwfRf5w4NJIQZLzRG+Zsd8Pex/VpnC94Q=
-github.com/massdriver-cloud/massdriver-sdk-go v0.2.10-0.20260721201746-c925c95365f7/go.mod h1:6NrSP+wfGQvUOAggsz10/Wkln8CKmk3VBnD+OJzZgFY=
-github.com/massdriver-cloud/massdriver-sdk-go v0.2.10 h1:KtRWFibrabU5shvIiIQMpYieg72gUq93omM39LuEPTw=
-github.com/massdriver-cloud/massdriver-sdk-go v0.2.10/go.mod h1:6NrSP+wfGQvUOAggsz10/Wkln8CKmk3VBnD+OJzZgFY=
-github.com/massdriver-cloud/massdriver-sdk-go v0.2.11 h1:8MXqxArkX3TO+UJpzRF7iexHVO08TocPDqGGk6twBeM=
-github.com/massdriver-cloud/massdriver-sdk-go v0.2.11/go.mod h1:6NrSP+wfGQvUOAggsz10/Wkln8CKmk3VBnD+OJzZgFY=
+github.com/massdriver-cloud/massdriver-sdk-go v0.2.15 h1:ZJjirglHljaZqrHu8/3HeNK7RkMBHL0ZJTfPtgYlQlg=
+github.com/massdriver-cloud/massdriver-sdk-go v0.2.15/go.mod h1:6NrSP+wfGQvUOAggsz10/Wkln8CKmk3VBnD+OJzZgFY=
 github.com/massdriver-cloud/terraform-config-inspect v0.0.2 h1:Jc7BrhFHLbK7Epig6ShiEVMzQPPHVIOx0/BatvtEwtY=
 github.com/massdriver-cloud/terraform-config-inspect v0.0.2/go.mod h1:3AbDpWxIRMdMAg7FDmTJuVBhCGNwdm49cBIOmUHjqRg=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=


### PR DESCRIPTION
## What

Bumps the massdriver-sdk-go dependency and updates the `project`, `environment`,
and `component` update commands to match the SDK's new `UpdateInput` shape.

The SDK changed `UpdateInput.Name` / `Description` from `string` to `*string`
(and added `*bool` fields elsewhere) so it can distinguish an **unset** field
from an intentionally **empty** one. A nil pointer / nil map now means "leave
this value unchanged at the server."

## Changes

- **Bump SDK** to `v0.2.15` (needed for `mass whoami`; also brings the pointer-based
  update inputs).
- **Only send changed fields.** Each update command now sets a field on `UpdateInput`
  only when its flag was explicitly passed (`cmd.Flags().Changed(...)`), letting nil
  signal "unchanged."
- **Drop the pre-update `Get` + backfill.** Previously each command fetched the current
  entity and re-sent every existing value so unset flags wouldn't blank the field. The
  server now handles the merge, so this extra round-trip is gone.
- **Reject no-op updates.** Running an update with no flags now errors with
  `nothing to update: set at least one of --name, --description, or --attributes`
  instead of silently making a meaningless API call that reported success.

## Why it matters

Before the pointer change, an argument-less update would have blanked name/description
at the server — the old backfill fetch masked that. With the fetch removed, the explicit
guard makes the "nothing to update" case a clear error rather than a misleading
"✅ updated".

## Testing

- `go build ./...` and `go vet ./cmd/` pass.
