### PR TITLE
Add `mass repository grant` and `mass resource grant`

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -397,6 +397,14 @@ linters:
         # Omit embedded fields from selector expression.
         # https://staticcheck.dev/docs/checks/#QF1008
         - -QF1008
+        # The doc-comment-form family: a comment on an exported symbol must
+        # begin with its name. Off for the same reason as revive's `exported`
+        # rule above — this module is a binary, not a library, so a comment
+        # here is free-form prose rather than generated API documentation.
+        # https://staticcheck.dev/docs/checks/#ST1020
+        - -ST1020
+        - -ST1021
+        - -ST1022
 
     usetesting:
       # Enable/disable `os.TempDir()` detections.
@@ -417,6 +425,10 @@ linters:
     # Allow unused params at the cobra command level
     - linters: [revive]
       text: "unused-parameter: parameter ('cmd'|'args') seems to be unused, consider removing or renaming it as _"
+    # This module ships a CLI binary, not a library. Nothing here is importable
+    # API, so doc comments are a judgement call rather than a requirement.
+    - linters: [revive]
+      text: "^exported:"
     - path: "_test\\.go"
       linters:
         - revive

--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -167,11 +167,11 @@ func NewCmdBundle() *cobra.Command { //nolint:funlen // cobra command builders a
 	bundleTemplateListCmd.Flags().StringP("output", "o", "text", "Output format (text, json)")
 
 	bundleCreateCmd := &cobra.Command{
-		Use:     "create <name>",
-		Short:   "Create a new bundle OCI repository in your organization's catalog",
-		Example: `mass bundle create aws-aurora-postgres -a owner=data,service=database`,
-		Args:    cobra.ExactArgs(1),
-		RunE:    runBundleCreate,
+		Use:   "create <name>",
+		Short: "Create a new bundle OCI repository in your organization's catalog",
+		Long:  helpdocs.MustRender("bundle/create"),
+		Args:  cobra.ExactArgs(1),
+		RunE:  runBundleCreate,
 	}
 	bundleCreateCmd.Flags().StringToStringP("attributes", "a", nil, "Custom attributes (e.g. -a owner=data,service=database)")
 

--- a/cmd/component.go
+++ b/cmd/component.go
@@ -24,12 +24,11 @@ func NewCmdComponent() *cobra.Command {
 	}
 
 	componentAddCmd := &cobra.Command{
-		Use:     "add <project-id> <bundle-oci-repo-name>",
-		Short:   "Add a component to a project's blueprint",
-		Example: `mass component add ecomm aws-rds-cluster --id db --name "Primary Database"`,
-		Long:    helpdocs.MustRender("component/add"),
-		Args:    cobra.ExactArgs(2),
-		RunE:    runComponentAdd,
+		Use:   "add <project-id> <bundle-oci-repo-name>",
+		Short: "Add a component to a project's blueprint",
+		Long:  helpdocs.MustRender("component/add"),
+		Args:  cobra.ExactArgs(2),
+		RunE:  runComponentAdd,
 	}
 	componentAddCmd.Flags().String("id", "", "Short identifier for this component (e.g., db). Max 20 chars, lowercase alphanumeric.")
 	componentAddCmd.Flags().StringP("name", "n", "", "Display name (defaults to --id if not provided)")
@@ -38,11 +37,11 @@ func NewCmdComponent() *cobra.Command {
 	_ = componentAddCmd.MarkFlagRequired("id")
 
 	componentUpdateCmd := &cobra.Command{
-		Use:     "update <component-id>",
-		Short:   "Update a component's name, description, or attributes",
-		Example: `mass component update ecomm-db --name "Primary DB" -a priority=high`,
-		Args:    cobra.ExactArgs(1),
-		RunE:    runComponentUpdate,
+		Use:   "update <component-id>",
+		Short: "Update a component's name, description, or attributes",
+		Long:  helpdocs.MustRender("component/update"),
+		Args:  cobra.ExactArgs(1),
+		RunE:  runComponentUpdate,
 	}
 	componentUpdateCmd.Flags().StringP("name", "n", "", "New display name")
 	componentUpdateCmd.Flags().StringP("description", "d", "", "New description")
@@ -52,30 +51,27 @@ func NewCmdComponent() *cobra.Command {
 		Use:     "remove <component-id>",
 		Aliases: []string{"rm"},
 		Short:   "Remove a component from a project's blueprint",
-		Example: `mass component remove ecomm-db`,
 		Long:    helpdocs.MustRender("component/remove"),
 		Args:    cobra.ExactArgs(1),
 		RunE:    runComponentRemove,
 	}
 
 	componentLinkCmd := &cobra.Command{
-		Use:     "link <from-component>.<from-field> <to-component>.<to-field>",
-		Short:   "Link two components in a project's blueprint",
-		Example: `mass component link ecomm-db.authentication ecomm-app.database --from-version ~1.0 --to-version ~2.0`,
-		Long:    helpdocs.MustRender("component/link"),
-		Args:    cobra.ExactArgs(2),
-		RunE:    runComponentLink,
+		Use:   "link <from-component>.<from-field> <to-component>.<to-field>",
+		Short: "Link two components in a project's blueprint",
+		Long:  helpdocs.MustRender("component/link"),
+		Args:  cobra.ExactArgs(2),
+		RunE:  runComponentLink,
 	}
 	componentLinkCmd.Flags().String("from-version", "latest", "Version constraint for the source component")
 	componentLinkCmd.Flags().String("to-version", "latest", "Version constraint for the destination component")
 
 	componentUnlinkCmd := &cobra.Command{
-		Use:     "unlink <from-component>.<from-field> <to-component>.<to-field>",
-		Short:   "Remove a link between two components",
-		Example: `mass component unlink ecomm-db.authentication ecomm-app.database`,
-		Long:    helpdocs.MustRender("component/unlink"),
-		Args:    cobra.ExactArgs(2),
-		RunE:    runComponentUnlink,
+		Use:   "unlink <from-component>.<from-field> <to-component>.<to-field>",
+		Short: "Remove a link between two components",
+		Long:  helpdocs.MustRender("component/unlink"),
+		Args:  cobra.ExactArgs(2),
+		RunE:  runComponentUnlink,
 	}
 
 	componentCmd.AddCommand(componentAddCmd)

--- a/cmd/deployment.go
+++ b/cmd/deployment.go
@@ -38,12 +38,11 @@ func NewCmdDeployment() *cobra.Command {
 	}
 
 	deploymentGetCmd := &cobra.Command{
-		Use:     "get <deployment-id>",
-		Short:   "Get a deployment by ID",
-		Example: `mass deployment get 12345678-1234-1234-1234-123456789012`,
-		Long:    helpdocs.MustRender("deployment/get"),
-		Args:    cobra.ExactArgs(1),
-		RunE:    runDeploymentGet,
+		Use:   "get <deployment-id>",
+		Short: "Get a deployment by ID",
+		Long:  helpdocs.MustRender("deployment/get"),
+		Args:  cobra.ExactArgs(1),
+		RunE:  runDeploymentGet,
 	}
 	deploymentGetCmd.Flags().StringP("output", "o", "text", "Output format (text or json)")
 
@@ -51,7 +50,6 @@ func NewCmdDeployment() *cobra.Command {
 		Use:     "list <instance-id>",
 		Aliases: []string{"ls"},
 		Short:   "List deployments for an instance (most recent first)",
-		Example: `mass deployment list ecomm-prod-db --limit 25`,
 		Long:    helpdocs.MustRender("deployment/list"),
 		Args:    cobra.ExactArgs(1),
 		RunE:    runDeploymentList,
@@ -64,47 +62,42 @@ func NewCmdDeployment() *cobra.Command {
 	deploymentListCmd.Flags().String("bundle", "", "Filter by bundle version (name@version) or release channel (name@latest)")
 
 	deploymentLogsCmd := &cobra.Command{
-		Use:     "logs <deployment-id>",
-		Short:   "Stream the log output from a deployment",
-		Example: `mass deployment logs 12345678-1234-1234-1234-123456789012`,
-		Long:    helpdocs.MustRender("deployment/logs"),
-		Args:    cobra.ExactArgs(1),
-		RunE:    runDeploymentLogs,
+		Use:   "logs <deployment-id>",
+		Short: "Stream the log output from a deployment",
+		Long:  helpdocs.MustRender("deployment/logs"),
+		Args:  cobra.ExactArgs(1),
+		RunE:  runDeploymentLogs,
 	}
 
 	deploymentAbortCmd := &cobra.Command{
-		Use:     "abort <deployment-id>",
-		Short:   "Abort a pending, approved, or running deployment",
-		Example: `mass deployment abort 12345678-1234-1234-1234-123456789012 --force`,
-		Long:    helpdocs.MustRender("deployment/abort"),
-		Args:    cobra.ExactArgs(1),
-		RunE:    runDeploymentAbort,
+		Use:   "abort <deployment-id>",
+		Short: "Abort a pending, approved, or running deployment",
+		Long:  helpdocs.MustRender("deployment/abort"),
+		Args:  cobra.ExactArgs(1),
+		RunE:  runDeploymentAbort,
 	}
 	deploymentAbortCmd.Flags().BoolP("force", "f", false, "Skip confirmation prompt")
 
 	deploymentApproveCmd := &cobra.Command{
-		Use:     "approve <deployment-id>",
-		Short:   "Approve a proposed deployment, releasing it to run",
-		Example: `mass deployment approve 12345678-1234-1234-1234-123456789012`,
-		Long:    helpdocs.MustRender("deployment/approve"),
-		Args:    cobra.ExactArgs(1),
-		RunE:    runDeploymentApprove,
+		Use:   "approve <deployment-id>",
+		Short: "Approve a proposed deployment, releasing it to run",
+		Long:  helpdocs.MustRender("deployment/approve"),
+		Args:  cobra.ExactArgs(1),
+		RunE:  runDeploymentApprove,
 	}
 
 	deploymentRejectCmd := &cobra.Command{
-		Use:     "reject <deployment-id>",
-		Short:   "Reject a proposed deployment, discarding it permanently",
-		Example: `mass deployment reject 12345678-1234-1234-1234-123456789012`,
-		Long:    helpdocs.MustRender("deployment/reject"),
-		Args:    cobra.ExactArgs(1),
-		RunE:    runDeploymentReject,
+		Use:   "reject <deployment-id>",
+		Short: "Reject a proposed deployment, discarding it permanently",
+		Long:  helpdocs.MustRender("deployment/reject"),
+		Args:  cobra.ExactArgs(1),
+		RunE:  runDeploymentReject,
 	}
 
 	deploymentCompareCmd := &cobra.Command{
 		Use:     "compare <source-deployment-id> <target-deployment-id>",
 		Aliases: []string{"diff"},
 		Short:   "Compare two deployments' bundle version and params",
-		Example: `mass deployment compare 1111... 2222...`,
 		Long:    helpdocs.MustRender("deployment/compare"),
 		Args:    cobra.ExactArgs(2),
 		RunE:    runDeploymentCompare,

--- a/cmd/environment.go
+++ b/cmd/environment.go
@@ -110,12 +110,11 @@ func NewCmdEnvironment() *cobra.Command {
 
 func newEnvironmentDeleteCmd() *cobra.Command {
 	c := &cobra.Command{
-		Use:     "delete [environment]",
-		Short:   "Delete an environment",
-		Example: `mass environment delete ecomm-staging`,
-		Long:    helpdocs.MustRender("environment/delete"),
-		Args:    cobra.ExactArgs(1),
-		RunE:    runEnvironmentDelete,
+		Use:   "delete [environment]",
+		Short: "Delete an environment",
+		Long:  helpdocs.MustRender("environment/delete"),
+		Args:  cobra.ExactArgs(1),
+		RunE:  runEnvironmentDelete,
 	}
 	c.Flags().BoolP("force", "f", false, "Skip confirmation prompt")
 	return c
@@ -126,7 +125,6 @@ func newEnvironmentCompareCmd() *cobra.Command {
 		Use:     "compare [source-environment] [target-environment]",
 		Aliases: []string{"diff"},
 		Short:   "Compare two environments instance-by-instance",
-		Example: `mass environment compare ecomm-staging ecomm-production`,
 		Long:    helpdocs.MustRender("environment/compare"),
 		Args:    cobra.ExactArgs(2),
 		RunE:    runEnvironmentCompare,
@@ -154,12 +152,11 @@ func newEnvironmentPreviewCmd() *cobra.Command {
 
 func newEnvironmentForkCmd() *cobra.Command {
 	c := &cobra.Command{
-		Use:     "fork [parent-environment] [new-ID]",
-		Short:   "Fork an existing environment",
-		Example: `mass environment fork ecomm-production staging`,
-		Long:    helpdocs.MustRender("environment/fork"),
-		Args:    cobra.ExactArgs(2),
-		RunE:    runEnvironmentFork,
+		Use:   "fork [parent-environment] [new-ID]",
+		Short: "Fork an existing environment",
+		Long:  helpdocs.MustRender("environment/fork"),
+		Args:  cobra.ExactArgs(2),
+		RunE:  runEnvironmentFork,
 	}
 	c.Flags().StringP("name", "n", "", "Environment name (defaults to new-ID if not provided)")
 	c.Flags().StringP("description", "d", "", "Optional environment description")
@@ -172,12 +169,11 @@ func newEnvironmentForkCmd() *cobra.Command {
 
 func newEnvironmentDeployCmd() *cobra.Command {
 	c := &cobra.Command{
-		Use:     "deploy [environment]",
-		Short:   "Deploy every instance in an environment, in dependency order",
-		Example: `mass environment deploy ecomm-staging --follow`,
-		Long:    helpdocs.MustRender("environment/deploy"),
-		Args:    cobra.ExactArgs(1),
-		RunE:    runEnvironmentDeploy,
+		Use:   "deploy [environment]",
+		Short: "Deploy every instance in an environment, in dependency order",
+		Long:  helpdocs.MustRender("environment/deploy"),
+		Args:  cobra.ExactArgs(1),
+		RunE:  runEnvironmentDeploy,
 	}
 	c.Flags().Bool("follow", false, "Stream every deployment's logs to stdout until the rollout completes. Each line is prefixed with the instance id.")
 	return c
@@ -185,12 +181,11 @@ func newEnvironmentDeployCmd() *cobra.Command {
 
 func newEnvironmentDecommissionCmd() *cobra.Command {
 	c := &cobra.Command{
-		Use:     "decommission [environment]",
-		Short:   "Decommission every instance in an environment, in reverse dependency order",
-		Example: `mass environment decommission ecomm-pr42 --follow`,
-		Long:    helpdocs.MustRender("environment/decommission"),
-		Args:    cobra.ExactArgs(1),
-		RunE:    runEnvironmentDecommission,
+		Use:   "decommission [environment]",
+		Short: "Decommission every instance in an environment, in reverse dependency order",
+		Long:  helpdocs.MustRender("environment/decommission"),
+		Args:  cobra.ExactArgs(1),
+		RunE:  runEnvironmentDecommission,
 	}
 	c.Flags().Bool("follow", false, "Stream every decommission deployment's logs to stdout until the rollout completes. Each line is prefixed with the instance id.")
 	return c

--- a/cmd/instance.go
+++ b/cmd/instance.go
@@ -40,12 +40,11 @@ func NewCmdInstance() *cobra.Command {
 	instanceDeployCmd := newInstanceDeployCmd()
 
 	instanceExportCmd := &cobra.Command{
-		Use:     `export <project>-<env>-<manifest>`,
-		Short:   "Export instances",
-		Example: `mass instance export ecomm-prod-vpc`,
-		Long:    helpdocs.MustRender("instance/export"),
-		Args:    cobra.ExactArgs(1),
-		RunE:    runInstanceExport,
+		Use:   `export <project>-<env>-<manifest>`,
+		Short: "Export instances",
+		Long:  helpdocs.MustRender("instance/export"),
+		Args:  cobra.ExactArgs(1),
+		RunE:  runInstanceExport,
 	}
 
 	// instance and infra are the same, lets reuse a get command/template here.
@@ -53,7 +52,6 @@ func NewCmdInstance() *cobra.Command {
 		Use:     `get  <project>-<env>-<manifest>`,
 		Short:   "Get an instance",
 		Aliases: []string{"g"},
-		Example: `mass instance get ecomm-prod-vpc`,
 		Long:    helpdocs.MustRender("instance/get"),
 		Args:    cobra.ExactArgs(1),
 		RunE:    runInstanceGet,
@@ -61,21 +59,19 @@ func NewCmdInstance() *cobra.Command {
 	instanceGetCmd.Flags().StringP("output", "o", "text", "Output format (text or json)")
 
 	instanceVersionCmd := &cobra.Command{
-		Use:     `version <instance-id>@<version>`,
-		Short:   "Set instance version",
-		Example: `mass instance version api-prod-db@latest`,
-		Long:    helpdocs.MustRender("instance/version"),
-		Args:    cobra.ExactArgs(1),
-		RunE:    runInstanceVersion,
+		Use:   `version <instance-id>@<version>`,
+		Short: "Set instance version",
+		Long:  helpdocs.MustRender("instance/version"),
+		Args:  cobra.ExactArgs(1),
+		RunE:  runInstanceVersion,
 	}
 
 	instanceDestroyCmd := &cobra.Command{
-		Use:     `destroy <project>-<env>-<manifest>`,
-		Short:   "Destroy (decommission) an instance",
-		Example: `mass instance destroy api-prod-db --force`,
-		Long:    "Destroy (decommission) an instance. This will permanently delete the instance and all its resources.",
-		Args:    cobra.ExactArgs(1),
-		RunE:    runInstanceDeploy,
+		Use:   `destroy <project>-<env>-<manifest>`,
+		Short: "Destroy (decommission) an instance",
+		Long:  helpdocs.MustRender("instance/destroy"),
+		Args:  cobra.ExactArgs(1),
+		RunE:  runInstanceDeploy,
 	}
 	instanceDestroyCmd.Flags().StringP("message", "m", "", "Add a message when decommissioning")
 	instanceDestroyCmd.Flags().BoolP("force", "f", false, "Skip confirmation prompt")
@@ -88,7 +84,6 @@ func NewCmdInstance() *cobra.Command {
 		Use:     `list <project>-<env>`,
 		Short:   "List instances in an environment",
 		Aliases: []string{"ls"},
-		Example: `mass instance list ecomm-prod`,
 		Long:    helpdocs.MustRender("instance/list"),
 		Args:    cobra.ExactArgs(1),
 		RunE:    runInstanceList,
@@ -99,12 +94,11 @@ func NewCmdInstance() *cobra.Command {
 	instanceListCmd.Flags().String("bundle", "", "Filter by bundle version (name@version) or release channel (name@latest)")
 
 	instanceOrphanCmd := &cobra.Command{
-		Use:     `orphan <project>-<env>-<manifest>`,
-		Short:   "Orphan an instance (reset to INITIALIZED, optionally clearing state locks)",
-		Example: `mass instance orphan api-prod-db --force`,
-		Long:    helpdocs.MustRender("instance/orphan"),
-		Args:    cobra.ExactArgs(1),
-		RunE:    runInstanceOrphan,
+		Use:   `orphan <project>-<env>-<manifest>`,
+		Short: "Orphan an instance (reset to INITIALIZED, optionally clearing state locks)",
+		Long:  helpdocs.MustRender("instance/orphan"),
+		Args:  cobra.ExactArgs(1),
+		RunE:  runInstanceOrphan,
 	}
 	instanceOrphanCmd.Flags().BoolP("force", "f", false, "Skip confirmation prompt")
 	instanceOrphanCmd.Flags().Bool("delete-state", false, "Also delete the remote Terraform/OpenTofu state files (irreversible)")
@@ -125,12 +119,11 @@ func NewCmdInstance() *cobra.Command {
 
 func newInstanceRollbackCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:     `rollback <deployment-id>`,
-		Short:   "Propose rolling an instance back to a past completed deployment",
-		Example: `mass instance rollback 12345678-1234-1234-1234-123456789012`,
-		Long:    helpdocs.MustRender("instance/rollback"),
-		Args:    cobra.ExactArgs(1),
-		RunE:    runInstanceRollback,
+		Use:   `rollback <deployment-id>`,
+		Short: "Propose rolling an instance back to a past completed deployment",
+		Long:  helpdocs.MustRender("instance/rollback"),
+		Args:  cobra.ExactArgs(1),
+		RunE:  runInstanceRollback,
 	}
 }
 
@@ -143,19 +136,17 @@ func newInstanceRemoteReferenceCmd() *cobra.Command {
 	}
 
 	setCmd := &cobra.Command{
-		Use:     "set <instance-id> <field> <resource-id>",
-		Short:   "Override a connection slot with a resource from another project",
-		Example: `mass instance remote-reference set ecomm-prod-api database ecomm-prod-db.postgres`,
-		Long:    helpdocs.MustRender("instance/remote-reference-set"),
-		Args:    cobra.ExactArgs(3),
-		RunE:    runInstanceRemoteReferenceSet,
+		Use:   "set <instance-id> <field> <resource-id>",
+		Short: "Override a connection slot with a resource from another project",
+		Long:  helpdocs.MustRender("instance/remote-reference-set"),
+		Args:  cobra.ExactArgs(3),
+		RunE:  runInstanceRemoteReferenceSet,
 	}
 
 	removeCmd := &cobra.Command{
 		Use:     "remove <instance-id> <field>",
 		Aliases: []string{"rm", "unset"},
 		Short:   "Remove a connection slot override, reverting to the blueprint wiring",
-		Example: `mass instance remote-reference remove ecomm-prod-api database`,
 		Long:    helpdocs.MustRender("instance/remote-reference-remove"),
 		Args:    cobra.ExactArgs(2),
 		RunE:    runInstanceRemoteReferenceRemove,
@@ -168,12 +159,11 @@ func newInstanceRemoteReferenceCmd() *cobra.Command {
 
 func newInstanceDeployCmd() *cobra.Command {
 	c := &cobra.Command{
-		Use:     `deploy <project>-<env>-<manifest>`,
-		Short:   "Deploy instances",
-		Example: `mass instance deploy ecomm-prod-vpc`,
-		Long:    helpdocs.MustRender("instance/deploy"),
-		Args:    cobra.ExactArgs(1),
-		RunE:    runInstanceDeploy,
+		Use:   `deploy <project>-<env>-<manifest>`,
+		Short: "Deploy instances",
+		Long:  helpdocs.MustRender("instance/deploy"),
+		Args:  cobra.ExactArgs(1),
+		RunE:  runInstanceDeploy,
 	}
 	c.Flags().StringP("message", "m", "", "Add a message when deploying")
 	c.Flags().StringP("params", "p", "", "Path to params json, tfvars or yaml file. Use '-' to read from stdin. When provided, the full configuration is replaced. Supports bash interpolation.")
@@ -191,7 +181,6 @@ func newInstanceCopyCmd() *cobra.Command {
 		Use:     `copy [source] --to [destination]`,
 		Aliases: []string{"promote"},
 		Short:   "Copy an instance's configuration to another instance of the same component",
-		Example: `mass instance promote ecomm-staging-db --to ecomm-production-db --copy-secrets`,
 		Long:    helpdocs.MustRender("instance/copy"),
 		Args:    cobra.ExactArgs(1),
 		RunE:    runInstanceCopy,

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -93,12 +93,11 @@ func NewCmdProject() *cobra.Command {
 	projectDeleteCmd.Flags().BoolP("force", "f", false, "Skip confirmation prompt")
 
 	projectCloneCmd := &cobra.Command{
-		Use:     "clone [source-project] [new-id]",
-		Short:   "Clone a project's blueprint into a new project",
-		Example: `mass project clone ecomm ecomm-copy`,
-		Long:    helpdocs.MustRender("project/clone"),
-		Args:    cobra.ExactArgs(2),
-		RunE:    runProjectClone,
+		Use:   "clone [source-project] [new-id]",
+		Short: "Clone a project's blueprint into a new project",
+		Long:  helpdocs.MustRender("project/clone"),
+		Args:  cobra.ExactArgs(2),
+		RunE:  runProjectClone,
 	}
 	projectCloneCmd.Flags().StringP("name", "n", "", "New project name (defaults to new-id if not provided)")
 	projectCloneCmd.Flags().StringP("description", "d", "", "Optional project description")

--- a/cmd/repository.go
+++ b/cmd/repository.go
@@ -14,7 +14,9 @@ import (
 	"time"
 
 	"github.com/charmbracelet/glamour"
+	"github.com/massdriver-cloud/mass/docs/helpdocs"
 	"github.com/massdriver-cloud/mass/internal/cli"
+	"github.com/massdriver-cloud/mass/internal/commands/grants"
 	cmdrepository "github.com/massdriver-cloud/mass/internal/commands/repository"
 	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver"
 	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/platform/ocirepos"
@@ -91,6 +93,7 @@ func NewCmdRepository() *cobra.Command {
 	repositoryCmd.AddCommand(repositoryCreateCmd)
 	repositoryCmd.AddCommand(repositoryUpdateCmd)
 	repositoryCmd.AddCommand(repositoryDeleteCmd)
+	repositoryCmd.AddCommand(newRepositoryGrantCmd())
 
 	return repositoryCmd
 }
@@ -417,5 +420,134 @@ func runRepositoryDelete(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("Repository %s deleted successfully\n", deleted.Name)
+	return nil
+}
+
+type repositoryGrantCreateInput struct {
+	conditions     []string
+	conditionsFile string
+	allProjects    bool
+	action         string
+}
+
+//nolint:dupl // parallel command trees per recipient kind, not redundant logic
+func newRepositoryGrantCmd() *cobra.Command {
+	repositoryGrantCmd := &cobra.Command{
+		Use:     "grant",
+		Aliases: []string{"grants"},
+		Short:   "Manage sharing grants on an OCI repository",
+		Long:    helpdocs.MustRender("repository/grant"),
+	}
+
+	createInput := repositoryGrantCreateInput{}
+	repositoryGrantCreateCmd := &cobra.Command{
+		Use:   "create <name>",
+		Short: "Share a repository with recipient projects",
+		Long:  helpdocs.MustRender("repository/grant-create"),
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+			return runRepositoryGrantCreate(args[0], &createInput)
+		},
+	}
+	repositoryGrantCreateCmd.Flags().StringArrayVar(&createInput.conditions, "condition", nil, "Recipient project attribute condition; repeat a key to accept a set of values, or write key=* to accept any value")
+	repositoryGrantCreateCmd.Flags().StringVar(&createInput.conditionsFile, "conditions-file", "", "Read recipient conditions from a JSON file")
+	repositoryGrantCreateCmd.Flags().BoolVar(&createInput.allProjects, "all-projects", false, "Share with every project in the organization")
+	repositoryGrantCreateCmd.Flags().StringVar(&createInput.action, "action", "", "Action to grant (default "+grants.ActionRepoPull+")")
+
+	repositoryGrantListCmd := &cobra.Command{
+		Use:     "list <name>",
+		Aliases: []string{"ls"},
+		Short:   "List the sharing grants on a repository",
+		Long:    helpdocs.MustRender("repository/grant-list"),
+		Args:    cobra.ExactArgs(1),
+		RunE:    runRepositoryGrantList,
+	}
+	repositoryGrantListCmd.Flags().StringP("output", "o", "table", "Output format (table, json)")
+
+	repositoryGrantDeleteCmd := &cobra.Command{
+		Use:   "delete <grant-id>",
+		Short: "Revoke a sharing grant by id",
+		Long:  helpdocs.MustRender("repository/grant-delete"),
+		Args:  cobra.ExactArgs(1),
+		RunE:  runRepositoryGrantDelete,
+	}
+
+	repositoryGrantCmd.AddCommand(repositoryGrantCreateCmd)
+	repositoryGrantCmd.AddCommand(repositoryGrantListCmd)
+	repositoryGrantCmd.AddCommand(repositoryGrantDeleteCmd)
+
+	return repositoryGrantCmd
+}
+
+func runRepositoryGrantCreate(name string, input *repositoryGrantCreateInput) error {
+	ctx := context.Background()
+
+	action, err := grants.ResolveRepoAction(input.action)
+	if err != nil {
+		return err
+	}
+	conditions, err := grants.ResolveConditions(input.conditions, input.conditionsFile, input.allProjects, "all-projects")
+	if err != nil {
+		return err
+	}
+
+	mdClient, err := massdriver.NewClient()
+	if err != nil {
+		return fmt.Errorf("error initializing massdriver client: %w", err)
+	}
+
+	grant, err := mdClient.OciRepos.CreateGrant(ctx, name, ocirepos.CreateGrantInput{
+		Action:              action,
+		RecipientConditions: conditions,
+	})
+	if err != nil {
+		return grants.NotFoundHint(err, "repository", name)
+	}
+
+	fmt.Printf("✅ Repository `%s` shared as `%s` with %s (grant %s)\n", name, grant.Action, grants.FormatConditions(grant.RecipientConditions), grant.ID)
+	return nil
+}
+
+func runRepositoryGrantList(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	name := args[0]
+	outputFormat, err := cmd.Flags().GetString("output")
+	if err != nil {
+		return err
+	}
+
+	cmd.SilenceUsage = true
+
+	mdClient, err := massdriver.NewClient()
+	if err != nil {
+		return fmt.Errorf("error initializing massdriver client: %w", err)
+	}
+
+	seq := mdClient.OciRepos.IterGrants(ctx, name, ocirepos.ListGrantsInput{})
+	return grants.NotFoundHint(grants.Render(seq, outputFormat, os.Stdout), "repository", name)
+}
+
+func runRepositoryGrantDelete(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	grantID := args[0]
+	cmd.SilenceUsage = true
+
+	if validateErr := grants.ValidateGrantID(grantID, "mass repository grant list <name>"); validateErr != nil {
+		return validateErr
+	}
+
+	mdClient, err := massdriver.NewClient()
+	if err != nil {
+		return fmt.Errorf("error initializing massdriver client: %w", err)
+	}
+
+	if deleteErr := mdClient.OciRepos.DeleteGrant(ctx, grantID); deleteErr != nil {
+		return deleteErr
+	}
+
+	fmt.Printf("Grant %s deleted successfully\n", grantID)
 	return nil
 }

--- a/cmd/resource.go
+++ b/cmd/resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/charmbracelet/glamour"
 	"github.com/massdriver-cloud/mass/docs/helpdocs"
 	"github.com/massdriver-cloud/mass/internal/cli"
+	"github.com/massdriver-cloud/mass/internal/commands/grants"
 	"github.com/massdriver-cloud/mass/internal/commands/resource"
 	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver"
 	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/platform/resources"
@@ -37,6 +38,7 @@ func NewCmdResource() *cobra.Command {
 	resourceCmd.AddCommand(newResourceUpdateCmd())
 	resourceCmd.AddCommand(newResourceDeleteCmd())
 	resourceCmd.AddCommand(newResourceListCmd())
+	resourceCmd.AddCommand(newResourceGrantCmd())
 
 	return resourceCmd
 }
@@ -65,12 +67,6 @@ func newResourceGetCmd() *cobra.Command {
 		Long:  helpdocs.MustRender("resource/get"),
 		Args:  cobra.ExactArgs(1),
 		RunE:  runResourceGet,
-		Example: `  # Get resource using UUID (imported resources)
-  mass resource get 12345678-1234-1234-1234-123456789012
-
-  # Get resource using friendly slug (provisioned resources)
-  mass resource get api-prod-database-connection
-  mass resource get api-prod-grpcapi-host -o json`,
 	}
 	resourceGetCmd.Flags().StringP("output", "o", "text", "Output format (text or json)")
 	return resourceGetCmd
@@ -83,12 +79,6 @@ func newResourceDownloadCmd() *cobra.Command {
 		Long:  helpdocs.MustRender("resource/download"),
 		Args:  cobra.ExactArgs(1),
 		RunE:  runResourceDownload,
-		Example: `  # Download resource using UUID (imported resources)
-  mass resource download 12345678-1234-1234-1234-123456789012
-
-  # Download resource using friendly slug (provisioned resources)
-  mass resource download api-prod-database-connection
-  mass resource download network-useast1-vpc-network -f yaml`,
 	}
 	resourceDownloadCmd.Flags().StringP("format", "f", "json", "Download format (json, yaml, etc.)")
 	return resourceDownloadCmd
@@ -101,11 +91,6 @@ func newResourceUpdateCmd() *cobra.Command {
 		Long:  helpdocs.MustRender("resource/update"),
 		Args:  cobra.ExactArgs(1),
 		RunE:  runResourceUpdate,
-		Example: `  # Update resource payload
-  mass resource update 12345678-1234-1234-1234-123456789012 -f resource.json
-
-  # Update resource payload and rename
-  mass resource update 12345678-1234-1234-1234-123456789012 -f resource.json -n new-name`,
 	}
 	resourceUpdateCmd.Flags().StringP("name", "n", "", "New resource name")
 	resourceUpdateCmd.Flags().StringP("file", "f", "", "Resource payload file")
@@ -117,13 +102,9 @@ func newResourceDeleteCmd() *cobra.Command {
 	resourceDeleteCmd := &cobra.Command{
 		Use:   "delete [resource-id]",
 		Short: "Delete a resource",
+		Long:  helpdocs.MustRender("resource/delete"),
 		Args:  cobra.ExactArgs(1),
 		RunE:  runResourceDelete,
-		Example: `  # Delete an imported resource
-  mass resource delete 12345678-1234-1234-1234-123456789012
-
-  # Skip the confirmation prompt
-  mass resource delete 12345678-1234-1234-1234-123456789012 --force`,
 	}
 	resourceDeleteCmd.Flags().BoolP("force", "f", false, "Skip confirmation prompt")
 	return resourceDeleteCmd
@@ -136,13 +117,6 @@ func newResourceListCmd() *cobra.Command {
 		Aliases: []string{"ls"},
 		Long:    helpdocs.MustRender("resource/list"),
 		RunE:    runResourceList,
-		Example: `  # List all resources
-  mass resource list
-
-  # Search and filter
-  mass resource list --search database
-  mass resource list --type aws-iam-role --origin provisioned
-  mass resource list --environment ecomm-prod -o json`,
 	}
 	resourceListCmd.Flags().StringP("output", "o", "table", "Output format (table, json)")
 	resourceListCmd.Flags().StringP("search", "s", "", "Full-text search across resource name")
@@ -450,5 +424,134 @@ func renderResource(res *types.Resource) error {
 	}
 
 	fmt.Print(out)
+	return nil
+}
+
+type resourceGrantCreateInput struct {
+	conditions      []string
+	conditionsFile  string
+	allEnvironments bool
+	action          string
+}
+
+//nolint:dupl // parallel command trees per recipient kind, not redundant logic
+func newResourceGrantCmd() *cobra.Command {
+	resourceGrantCmd := &cobra.Command{
+		Use:     "grant",
+		Aliases: []string{"grants"},
+		Short:   "Manage sharing grants on a resource",
+		Long:    helpdocs.MustRender("resource/grant"),
+	}
+
+	createInput := resourceGrantCreateInput{}
+	resourceGrantCreateCmd := &cobra.Command{
+		Use:   "create <resource-id>",
+		Short: "Share a resource with recipient environments",
+		Long:  helpdocs.MustRender("resource/grant-create"),
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+			return runResourceGrantCreate(args[0], &createInput)
+		},
+	}
+	resourceGrantCreateCmd.Flags().StringArrayVar(&createInput.conditions, "condition", nil, "Recipient environment attribute condition; repeat a key to accept a set of values, or write key=* to accept any value")
+	resourceGrantCreateCmd.Flags().StringVar(&createInput.conditionsFile, "conditions-file", "", "Read recipient conditions from a JSON file")
+	resourceGrantCreateCmd.Flags().BoolVar(&createInput.allEnvironments, "all-environments", false, "Share with every environment in the organization")
+	resourceGrantCreateCmd.Flags().StringVar(&createInput.action, "action", "", "Action to grant (default "+grants.ActionResourceExport+")")
+
+	resourceGrantListCmd := &cobra.Command{
+		Use:     "list <resource-id>",
+		Aliases: []string{"ls"},
+		Short:   "List the sharing grants on a resource",
+		Long:    helpdocs.MustRender("resource/grant-list"),
+		Args:    cobra.ExactArgs(1),
+		RunE:    runResourceGrantList,
+	}
+	resourceGrantListCmd.Flags().StringP("output", "o", "table", "Output format (table, json)")
+
+	resourceGrantDeleteCmd := &cobra.Command{
+		Use:   "delete <grant-id>",
+		Short: "Revoke a sharing grant by id",
+		Long:  helpdocs.MustRender("resource/grant-delete"),
+		Args:  cobra.ExactArgs(1),
+		RunE:  runResourceGrantDelete,
+	}
+
+	resourceGrantCmd.AddCommand(resourceGrantCreateCmd)
+	resourceGrantCmd.AddCommand(resourceGrantListCmd)
+	resourceGrantCmd.AddCommand(resourceGrantDeleteCmd)
+
+	return resourceGrantCmd
+}
+
+func runResourceGrantCreate(resourceID string, input *resourceGrantCreateInput) error {
+	ctx := context.Background()
+
+	action, err := grants.ResolveResourceAction(input.action)
+	if err != nil {
+		return err
+	}
+	conditions, err := grants.ResolveConditions(input.conditions, input.conditionsFile, input.allEnvironments, "all-environments")
+	if err != nil {
+		return err
+	}
+
+	mdClient, err := massdriver.NewClient()
+	if err != nil {
+		return fmt.Errorf("error initializing massdriver client: %w", err)
+	}
+
+	grant, err := mdClient.Resources.CreateGrant(ctx, resourceID, resources.CreateGrantInput{
+		Action:              action,
+		RecipientConditions: conditions,
+	})
+	if err != nil {
+		return grants.NotFoundHint(err, "resource", resourceID)
+	}
+
+	fmt.Printf("✅ Resource `%s` shared as `%s` with %s (grant %s)\n", resourceID, grant.Action, grants.FormatConditions(grant.RecipientConditions), grant.ID)
+	return nil
+}
+
+func runResourceGrantList(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	resourceID := args[0]
+	outputFormat, err := cmd.Flags().GetString("output")
+	if err != nil {
+		return err
+	}
+
+	cmd.SilenceUsage = true
+
+	mdClient, err := massdriver.NewClient()
+	if err != nil {
+		return fmt.Errorf("error initializing massdriver client: %w", err)
+	}
+
+	seq := mdClient.Resources.IterGrants(ctx, resourceID, resources.ListGrantsInput{})
+	return grants.NotFoundHint(grants.Render(seq, outputFormat, os.Stdout), "resource", resourceID)
+}
+
+func runResourceGrantDelete(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	grantID := args[0]
+	cmd.SilenceUsage = true
+
+	if validateErr := grants.ValidateGrantID(grantID, "mass resource grant list <resource-id>"); validateErr != nil {
+		return validateErr
+	}
+
+	mdClient, err := massdriver.NewClient()
+	if err != nil {
+		return fmt.Errorf("error initializing massdriver client: %w", err)
+	}
+
+	if deleteErr := mdClient.Resources.DeleteGrant(ctx, grantID); deleteErr != nil {
+		return deleteErr
+	}
+
+	fmt.Printf("Grant %s deleted successfully\n", grantID)
 	return nil
 }

--- a/cmd/resource_type.go
+++ b/cmd/resource_type.go
@@ -38,12 +38,11 @@ func NewCmdType() *cobra.Command {
 	}
 
 	typeCreateCmd := &cobra.Command{
-		Use:     "create <name>",
-		Short:   "Create a new resource type OCI repository in your organization's catalog",
-		Long:    helpdocs.MustRender("type/create"),
-		Example: `mass resource-type create my-resource-type -a owner=data,service=database`,
-		Args:    cobra.ExactArgs(1),
-		RunE:    runTypeCreate,
+		Use:   "create <name>",
+		Short: "Create a new resource type OCI repository in your organization's catalog",
+		Long:  helpdocs.MustRender("type/create"),
+		Args:  cobra.ExactArgs(1),
+		RunE:  runTypeCreate,
 	}
 	typeCreateCmd.Flags().StringToStringP("attributes", "a", nil, "Custom attributes (e.g. -a owner=data,service=database)")
 
@@ -71,7 +70,6 @@ func NewCmdType() *cobra.Command {
 		Aliases: []string{"push"},
 		Short:   "Publish a resource type to Massdriver",
 		Long:    helpdocs.MustRender("type/publish"),
-		Example: `mass resource-type publish ./my-resource-type`,
 		Args:    cobra.MaximumNArgs(1),
 		RunE:    runTypePublish,
 	}

--- a/docs/generated/mass_bundle_create.md
+++ b/docs/generated/mass_bundle_create.md
@@ -8,14 +8,40 @@ sidebar_label: Mass Bundle Create
 
 Create a new bundle OCI repository in your organization's catalog
 
-```
+### Synopsis
+
+# Create Bundle Repository
+
+Creates an empty bundle OCI repository in your organization's catalog. The repository holds published versions of a bundle; create it before the first `mass bundle publish`.
+
+## Usage
+
+```bash
 mass bundle create <name> [flags]
 ```
 
-### Examples
+## Flags
+
+- `-a, --attributes` — custom attributes for ABAC (repeat or comma-separate)
+
+## Examples
+
+```bash
+# Create a repository for an Aurora Postgres bundle
+mass bundle create aws-aurora-postgres
+
+# Tag it with attributes policies and grants can match on
+mass bundle create aws-aurora-postgres -a owner=data,service=database
+```
+
+## Notes
+
+- This is `mass repository create --type bundle` with the type filled in.
+- Share the repository with other projects using `mass repository grant create`.
+
 
 ```
-mass bundle create aws-aurora-postgres -a owner=data,service=database
+mass bundle create <name> [flags]
 ```
 
 ### Options

--- a/docs/generated/mass_component_add.md
+++ b/docs/generated/mass_component_add.md
@@ -39,12 +39,6 @@ mass component add ecomm aws-rds-cluster --id db \
 mass component add <project-id> <bundle-oci-repo-name> [flags]
 ```
 
-### Examples
-
-```
-mass component add ecomm aws-rds-cluster --id db --name "Primary Database"
-```
-
 ### Options
 
 ```

--- a/docs/generated/mass_component_link.md
+++ b/docs/generated/mass_component_link.md
@@ -41,12 +41,6 @@ mass component link ecomm-db.authentication ecomm-app.database \
 mass component link <from-component>.<from-field> <to-component>.<to-field> [flags]
 ```
 
-### Examples
-
-```
-mass component link ecomm-db.authentication ecomm-app.database --from-version ~1.0 --to-version ~2.0
-```
-
 ### Options
 
 ```

--- a/docs/generated/mass_component_remove.md
+++ b/docs/generated/mass_component_remove.md
@@ -33,12 +33,6 @@ mass component remove ecomm-db
 mass component remove <component-id> [flags]
 ```
 
-### Examples
-
-```
-mass component remove ecomm-db
-```
-
 ### Options
 
 ```

--- a/docs/generated/mass_component_unlink.md
+++ b/docs/generated/mass_component_unlink.md
@@ -31,12 +31,6 @@ mass component unlink ecomm-db.authentication ecomm-app.database
 mass component unlink <from-component>.<from-field> <to-component>.<to-field> [flags]
 ```
 
-### Examples
-
-```
-mass component unlink ecomm-db.authentication ecomm-app.database
-```
-
 ### Options
 
 ```

--- a/docs/generated/mass_component_update.md
+++ b/docs/generated/mass_component_update.md
@@ -8,14 +8,42 @@ sidebar_label: Mass Component Update
 
 Update a component's name, description, or attributes
 
-```
+### Synopsis
+
+# Update Component
+
+Updates a component's display name, description, or custom attributes.
+
+Attributes are replaced wholesale rather than merged, so pass every attribute you want to keep.
+
+## Usage
+
+```bash
 mass component update <component-id> [flags]
 ```
 
-### Examples
+## Flags
+
+- `-n, --name` — new display name
+- `-d, --description` — new description
+- `-a, --attributes` — replacement custom attributes (repeat or comma-separate)
+
+## Examples
+
+```bash
+# Rename a component
+mass component update ecomm-db --name "Primary DB"
+
+# Rename and retag it in one call
+mass component update ecomm-db --name "Primary DB" -a priority=high
+
+# Replace the full attribute set
+mass component update ecomm-db -a priority=high,cost-center=engineering
+```
+
 
 ```
-mass component update ecomm-db --name "Primary DB" -a priority=high
+mass component update <component-id> [flags]
 ```
 
 ### Options

--- a/docs/generated/mass_deployment_abort.md
+++ b/docs/generated/mass_deployment_abort.md
@@ -44,12 +44,6 @@ mass deployment abort 12345678-1234-1234-1234-123456789012 --force
 mass deployment abort <deployment-id> [flags]
 ```
 
-### Examples
-
-```
-mass deployment abort 12345678-1234-1234-1234-123456789012 --force
-```
-
 ### Options
 
 ```

--- a/docs/generated/mass_deployment_approve.md
+++ b/docs/generated/mass_deployment_approve.md
@@ -33,12 +33,6 @@ mass deployment approve 12345678-1234-1234-1234-123456789012
 mass deployment approve <deployment-id> [flags]
 ```
 
-### Examples
-
-```
-mass deployment approve 12345678-1234-1234-1234-123456789012
-```
-
 ### Options
 
 ```

--- a/docs/generated/mass_deployment_compare.md
+++ b/docs/generated/mass_deployment_compare.md
@@ -47,12 +47,6 @@ mass deployment compare 1111... 2222... -o json
 mass deployment compare <source-deployment-id> <target-deployment-id> [flags]
 ```
 
-### Examples
-
-```
-mass deployment compare 1111... 2222...
-```
-
 ### Options
 
 ```

--- a/docs/generated/mass_deployment_get.md
+++ b/docs/generated/mass_deployment_get.md
@@ -32,12 +32,6 @@ mass deployment get 12345678-1234-1234-1234-123456789012 --output json
 mass deployment get <deployment-id> [flags]
 ```
 
-### Examples
-
-```
-mass deployment get 12345678-1234-1234-1234-123456789012
-```
-
 ### Options
 
 ```

--- a/docs/generated/mass_deployment_list.md
+++ b/docs/generated/mass_deployment_list.md
@@ -35,12 +35,6 @@ mass deployment list ecomm-prod-db --limit 50
 mass deployment list <instance-id> [flags]
 ```
 
-### Examples
-
-```
-mass deployment list ecomm-prod-db --limit 25
-```
-
 ### Options
 
 ```

--- a/docs/generated/mass_deployment_logs.md
+++ b/docs/generated/mass_deployment_logs.md
@@ -31,12 +31,6 @@ mass deployment logs 12345678-1234-1234-1234-123456789012
 mass deployment logs <deployment-id> [flags]
 ```
 
-### Examples
-
-```
-mass deployment logs 12345678-1234-1234-1234-123456789012
-```
-
 ### Options
 
 ```

--- a/docs/generated/mass_deployment_reject.md
+++ b/docs/generated/mass_deployment_reject.md
@@ -33,12 +33,6 @@ mass deployment reject 12345678-1234-1234-1234-123456789012
 mass deployment reject <deployment-id> [flags]
 ```
 
-### Examples
-
-```
-mass deployment reject 12345678-1234-1234-1234-123456789012
-```
-
 ### Options
 
 ```

--- a/docs/generated/mass_environment_compare.md
+++ b/docs/generated/mass_environment_compare.md
@@ -47,12 +47,6 @@ mass environment compare ecomm-staging ecomm-production -o json
 mass environment compare [source-environment] [target-environment] [flags]
 ```
 
-### Examples
-
-```
-mass environment compare ecomm-staging ecomm-production
-```
-
 ### Options
 
 ```

--- a/docs/generated/mass_environment_decommission.md
+++ b/docs/generated/mass_environment_decommission.md
@@ -62,12 +62,6 @@ mass environment delete ecomm-pr42
 mass environment decommission [environment] [flags]
 ```
 
-### Examples
-
-```
-mass environment decommission ecomm-pr42 --follow
-```
-
 ### Options
 
 ```

--- a/docs/generated/mass_environment_delete.md
+++ b/docs/generated/mass_environment_delete.md
@@ -47,12 +47,6 @@ mass environment delete ecomm-staging --force
 mass environment delete [environment] [flags]
 ```
 
-### Examples
-
-```
-mass environment delete ecomm-staging
-```
-
 ### Options
 
 ```

--- a/docs/generated/mass_environment_deploy.md
+++ b/docs/generated/mass_environment_deploy.md
@@ -45,17 +45,14 @@ mass environment deploy ecomm-staging
 # Deploy a freshly-forked preview env.
 mass environment fork ecomm-production pr42 --copy-environment-defaults
 mass environment deploy ecomm-pr42
+
+# Stream every instance's logs until the rollout finishes.
+mass environment deploy ecomm-staging --follow
 ```
 
 
 ```
 mass environment deploy [environment] [flags]
-```
-
-### Examples
-
-```
-mass environment deploy ecomm-staging --follow
 ```
 
 ### Options

--- a/docs/generated/mass_environment_fork.md
+++ b/docs/generated/mass_environment_fork.md
@@ -65,12 +65,6 @@ mass environment fork ecomm-production staging --copy-environment-defaults
 mass environment fork [parent-environment] [new-ID] [flags]
 ```
 
-### Examples
-
-```
-mass environment fork ecomm-production staging
-```
-
 ### Options
 
 ```

--- a/docs/generated/mass_instance_copy.md
+++ b/docs/generated/mass_instance_copy.md
@@ -67,12 +67,6 @@ mass instance copy ecomm-staging-db \
 mass instance copy [source] --to [destination] [flags]
 ```
 
-### Examples
-
-```
-mass instance promote ecomm-staging-db --to ecomm-production-db --copy-secrets
-```
-
 ### Options
 
 ```

--- a/docs/generated/mass_instance_deploy.md
+++ b/docs/generated/mass_instance_deploy.md
@@ -74,12 +74,6 @@ mass instance deploy ecomm-prod-db --propose --message "bump db to 13.4" --patch
 mass instance deploy <project>-<env>-<manifest> [flags]
 ```
 
-### Examples
-
-```
-mass instance deploy ecomm-prod-vpc
-```
-
 ### Options
 
 ```

--- a/docs/generated/mass_instance_destroy.md
+++ b/docs/generated/mass_instance_destroy.md
@@ -10,16 +10,40 @@ Destroy (decommission) an instance
 
 ### Synopsis
 
-Destroy (decommission) an instance. This will permanently delete the instance and all its resources.
+# Destroy Instance
 
-```
+Destroys (decommissions) an instance. This permanently deletes the instance and all the resources it provisioned.
+
+## Usage
+
+```bash
 mass instance destroy <project>-<env>-<manifest> [flags]
 ```
 
-### Examples
+## Flags
+
+- `-m, --message` — add a message when decommissioning
+- `-f, --force` — skip the confirmation prompt
+- `-p, --params` — path to a params json, tfvars or yaml file; `-` reads stdin
+- `-P, --patch` — patch the last deployed configuration with a JQ expression (repeatable)
+- `--follow` — stream the deployment's logs to stdout until it completes
+
+## Examples
+
+```bash
+# Destroy an instance, confirming at the prompt
+mass instance destroy api-prod-db
+
+# Skip the prompt, for scripted teardown
+mass instance destroy api-prod-db --force
+
+# Destroy and watch the logs until it finishes
+mass instance destroy api-prod-db --force --follow
+```
+
 
 ```
-mass instance destroy api-prod-db --force
+mass instance destroy <project>-<env>-<manifest> [flags]
 ```
 
 ### Options

--- a/docs/generated/mass_instance_export.md
+++ b/docs/generated/mass_instance_export.md
@@ -51,12 +51,6 @@ mass instance export web-prod-app
 mass instance export <project>-<env>-<manifest> [flags]
 ```
 
-### Examples
-
-```
-mass instance export ecomm-prod-vpc
-```
-
 ### Options
 
 ```

--- a/docs/generated/mass_instance_get.md
+++ b/docs/generated/mass_instance_get.md
@@ -36,12 +36,6 @@ The instance slug can be found by hovering over the bundle in the Massdriver dia
 mass instance get  <project>-<env>-<manifest> [flags]
 ```
 
-### Examples
-
-```
-mass instance get ecomm-prod-vpc
-```
-
 ### Options
 
 ```

--- a/docs/generated/mass_instance_list.md
+++ b/docs/generated/mass_instance_list.md
@@ -32,12 +32,6 @@ mass instance list ecomm-prod
 mass instance list <project>-<env> [flags]
 ```
 
-### Examples
-
-```
-mass instance list ecomm-prod
-```
-
 ### Options
 
 ```

--- a/docs/generated/mass_instance_orphan.md
+++ b/docs/generated/mass_instance_orphan.md
@@ -41,12 +41,6 @@ mass instance orphan api-prod-db --delete-state
 mass instance orphan <project>-<env>-<manifest> [flags]
 ```
 
-### Examples
-
-```
-mass instance orphan api-prod-db --force
-```
-
 ### Options
 
 ```

--- a/docs/generated/mass_instance_remote-reference_remove.md
+++ b/docs/generated/mass_instance_remote-reference_remove.md
@@ -35,12 +35,6 @@ mass instance remote-reference remove ecomm-prod-api database
 mass instance remote-reference remove <instance-id> <field> [flags]
 ```
 
-### Examples
-
-```
-mass instance remote-reference remove ecomm-prod-api database
-```
-
 ### Options
 
 ```

--- a/docs/generated/mass_instance_remote-reference_set.md
+++ b/docs/generated/mass_instance_remote-reference_set.md
@@ -42,12 +42,6 @@ mass instance remote-reference set ecomm-prod-api database 12345678-1234-1234-12
 mass instance remote-reference set <instance-id> <field> <resource-id> [flags]
 ```
 
-### Examples
-
-```
-mass instance remote-reference set ecomm-prod-api database ecomm-prod-db.postgres
-```
-
 ### Options
 
 ```

--- a/docs/generated/mass_instance_rollback.md
+++ b/docs/generated/mass_instance_rollback.md
@@ -39,12 +39,6 @@ mass deployment approve <proposed-deployment-id>
 mass instance rollback <deployment-id> [flags]
 ```
 
-### Examples
-
-```
-mass instance rollback 12345678-1234-1234-1234-123456789012
-```
-
 ### Options
 
 ```

--- a/docs/generated/mass_instance_version.md
+++ b/docs/generated/mass_instance_version.md
@@ -36,12 +36,6 @@ The version can be:
 mass instance version <instance-id>@<version> [flags]
 ```
 
-### Examples
-
-```
-mass instance version api-prod-db@latest
-```
-
 ### Options
 
 ```

--- a/docs/generated/mass_project_clone.md
+++ b/docs/generated/mass_project_clone.md
@@ -46,12 +46,6 @@ mass project clone ecomm ecomm-eu -n "Ecomm (EU)" -a region=eu
 mass project clone [source-project] [new-id] [flags]
 ```
 
-### Examples
-
-```
-mass project clone ecomm ecomm-copy
-```
-
 ### Options
 
 ```

--- a/docs/generated/mass_repository.md
+++ b/docs/generated/mass_repository.md
@@ -20,5 +20,6 @@ Manage OCI repositories (bundles and resource types)
 * [mass repository create](/cli/commands/mass_repository_create)	 - Create a new OCI repository
 * [mass repository delete](/cli/commands/mass_repository_delete)	 - Delete an OCI repository
 * [mass repository get](/cli/commands/mass_repository_get)	 - Get an OCI repository by name
+* [mass repository grant](/cli/commands/mass_repository_grant)	 - Manage sharing grants on an OCI repository
 * [mass repository list](/cli/commands/mass_repository_list)	 - List OCI repositories
 * [mass repository update](/cli/commands/mass_repository_update)	 - Update an OCI repository's attributes

--- a/docs/generated/mass_repository_grant.md
+++ b/docs/generated/mass_repository_grant.md
@@ -1,0 +1,46 @@
+---
+id: mass_repository_grant.md
+slug: /cli/commands/mass_repository_grant
+title: Mass Repository Grant
+sidebar_label: Mass Repository Grant
+---
+## mass repository grant
+
+Manage sharing grants on an OCI repository
+
+### Synopsis
+
+# Repository Grants
+
+Manages the sharing grants on an OCI repository.
+
+A grant says "this repository is shared as `<action>`, to recipient projects matching `<conditions>`." Without a grant, a repository is visible only where it was published.
+
+Grants are immutable. To change an action or its conditions, delete the grant and create a replacement.
+
+## Usage
+
+```bash
+mass repository grant create <name> [flags]
+mass repository grant list <name> [flags]
+mass repository grant delete <grant-id>
+```
+
+## Notes
+
+- Creating or deleting a grant requires the `repo:grant` action on the repository.
+- Recipients are matched on **project** attributes. Resource grants match on environment attributes instead — see `mass resource grant`.
+
+
+### Options
+
+```
+  -h, --help   help for grant
+```
+
+### SEE ALSO
+
+* [mass repository](/cli/commands/mass_repository)	 - Manage OCI repositories (bundles and resource types)
+* [mass repository grant create](/cli/commands/mass_repository_grant_create)	 - Share a repository with recipient projects
+* [mass repository grant delete](/cli/commands/mass_repository_grant_delete)	 - Revoke a sharing grant by id
+* [mass repository grant list](/cli/commands/mass_repository_grant_list)	 - List the sharing grants on a repository

--- a/docs/generated/mass_repository_grant_create.md
+++ b/docs/generated/mass_repository_grant_create.md
@@ -1,0 +1,88 @@
+---
+id: mass_repository_grant_create.md
+slug: /cli/commands/mass_repository_grant_create
+title: Mass Repository Grant Create
+sidebar_label: Mass Repository Grant Create
+---
+## mass repository grant create
+
+Share a repository with recipient projects
+
+### Synopsis
+
+# Create Repository Grant
+
+Shares an OCI repository with recipient projects, so they can pull it.
+
+Recipients are chosen by matching **project** attributes. You must say who the recipients are: either name conditions with `--condition` / `--conditions-file`, or share with the whole organization with `--all-projects`. Leaving it unstated is an error rather than a silent org-wide grant.
+
+## Usage
+
+```bash
+mass repository grant create <name> [flags]
+```
+
+## Flags
+
+- `--condition` — a recipient project attribute condition, `key=value`. Repeat the same key to accept a set of values; write `key=*` to accept any value as long as the attribute is set.
+- `--conditions-file` — read conditions from a JSON file instead
+- `--all-projects` — share with every project in the organization
+- `--action` — the action to grant. Defaults to `repo:pull`, currently the only grantable repository action.
+
+`--condition`, `--conditions-file`, and `--all-projects` are mutually exclusive.
+
+## Examples
+
+```bash
+# Share with projects whose team attribute is platform or data
+mass repository grant create aws-aurora-postgres \
+  --condition team=platform \
+  --condition team=data
+
+# Share with projects that have any region attribute set
+mass repository grant create aws-aurora-postgres --condition 'region=*'
+
+# Share with every project in the organization
+mass repository grant create aws-aurora-postgres --all-projects
+
+# Read conditions from a JSON file
+mass repository grant create aws-aurora-postgres --conditions-file ./conditions.json
+```
+
+## Conditions file format
+
+One JSON object, shaped like a grant's `recipientConditions` in `mass repository grant list -o json`. Values are either `"*"` for the per-key wildcard or an array of accepted values:
+
+```json
+{
+  "team": ["platform", "data"],
+  "region": "*"
+}
+```
+
+A file holding `null` or `{}` is rejected — use `--all-projects` to share organization-wide, so the broadest grant is always explicit.
+
+## Notes
+
+- Quote `key=*` so your shell does not expand the `*`.
+- A comma is an ordinary character in a condition value. Unlike `--attributes`, it does not separate pairs.
+- Grants are immutable; to change one, delete it and create a replacement.
+
+
+```
+mass repository grant create <name> [flags]
+```
+
+### Options
+
+```
+      --action string            Action to grant (default repo:pull)
+      --all-projects             Share with every project in the organization
+      --condition stringArray    Recipient project attribute condition; repeat a key to accept a set of values, or write key=* to accept any value
+      --conditions-file string   Read recipient conditions from a JSON file
+  -h, --help                     help for create
+```
+
+### SEE ALSO
+
+* [mass repository grant](/cli/commands/mass_repository_grant)	 - Manage sharing grants on an OCI repository

--- a/docs/generated/mass_repository_grant_delete.md
+++ b/docs/generated/mass_repository_grant_delete.md
@@ -1,0 +1,49 @@
+---
+id: mass_repository_grant_delete.md
+slug: /cli/commands/mass_repository_grant_delete
+title: Mass Repository Grant Delete
+sidebar_label: Mass Repository Grant Delete
+---
+## mass repository grant delete
+
+Revoke a sharing grant by id
+
+### Synopsis
+
+# Delete Repository Grant
+
+Revokes a sharing grant by id. Recipients that qualified only through this grant immediately lose access to the repository.
+
+## Usage
+
+```bash
+mass repository grant delete <grant-id>
+```
+
+## Examples
+
+```bash
+# Find the grant id, then revoke it
+mass repository grant list aws-aurora-postgres
+mass repository grant delete 4f2a9c18-1f0e-4a5c-9a3e-2b6d7c8e9f10
+```
+
+## Notes
+
+- Grants are immutable, so changing one means deleting it and creating a replacement.
+- This does not prompt for confirmation. A revoked grant can be re-created with `mass repository grant create`.
+
+
+```
+mass repository grant delete <grant-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for delete
+```
+
+### SEE ALSO
+
+* [mass repository grant](/cli/commands/mass_repository_grant)	 - Manage sharing grants on an OCI repository

--- a/docs/generated/mass_repository_grant_list.md
+++ b/docs/generated/mass_repository_grant_list.md
@@ -1,0 +1,58 @@
+---
+id: mass_repository_grant_list.md
+slug: /cli/commands/mass_repository_grant_list
+title: Mass Repository Grant List
+sidebar_label: Mass Repository Grant List
+---
+## mass repository grant list
+
+List the sharing grants on a repository
+
+### Synopsis
+
+# List Repository Grants
+
+Lists the sharing grants authored on an OCI repository — what it is shared as, and which recipient projects qualify.
+
+If you can see a repository you can see all of its grants; they are publisher-side metadata rather than being visibility-gated themselves.
+
+## Usage
+
+```bash
+mass repository grant list <name> [flags]
+```
+
+## Flags
+
+- `-o, --output` — output format: `table` or `json`
+
+## Examples
+
+```bash
+# List the grants on a repository
+mass repository grant list aws-aurora-postgres
+
+# As JSON, for scripting
+mass repository grant list aws-aurora-postgres -o json
+```
+
+## Notes
+
+- The `Recipients` column reads `everyone` for an organization-wide grant, `key=*` for a per-key wildcard, and `key=a|b` for a closed set.
+- The `ID` column is what `mass repository grant delete` takes.
+
+
+```
+mass repository grant list <name> [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for list
+  -o, --output string   Output format (table, json) (default "table")
+```
+
+### SEE ALSO
+
+* [mass repository grant](/cli/commands/mass_repository_grant)	 - Manage sharing grants on an OCI repository

--- a/docs/generated/mass_resource-type_create.md
+++ b/docs/generated/mass_resource-type_create.md
@@ -37,12 +37,6 @@ mass resource-type create my-resource-type -a owner=data,service=database
 mass resource-type create <name> [flags]
 ```
 
-### Examples
-
-```
-mass resource-type create my-resource-type -a owner=data,service=database
-```
-
 ### Options
 
 ```

--- a/docs/generated/mass_resource-type_publish.md
+++ b/docs/generated/mass_resource-type_publish.md
@@ -67,12 +67,6 @@ mass resource-type convert ./my-resource-type.json
 mass resource-type publish [path] [flags]
 ```
 
-### Examples
-
-```
-mass resource-type publish ./my-resource-type
-```
-
 ### Options
 
 ```

--- a/docs/generated/mass_resource.md
+++ b/docs/generated/mass_resource.md
@@ -28,5 +28,6 @@ Resources represent infrastructure outputs and connections in Massdriver. They c
 * [mass resource delete](/cli/commands/mass_resource_delete)	 - Delete a resource
 * [mass resource download](/cli/commands/mass_resource_download)	 - Download an resource in the specified format
 * [mass resource get](/cli/commands/mass_resource_get)	 - Get an resource from Massdriver
+* [mass resource grant](/cli/commands/mass_resource_grant)	 - Manage sharing grants on a resource
 * [mass resource list](/cli/commands/mass_resource_list)	 - List resources
 * [mass resource update](/cli/commands/mass_resource_update)	 - Update an imported resource

--- a/docs/generated/mass_resource_delete.md
+++ b/docs/generated/mass_resource_delete.md
@@ -8,18 +8,37 @@ sidebar_label: Mass Resource Delete
 
 Delete a resource
 
+### Synopsis
+
+# Delete Resource
+
+Deletes an imported resource from your organization.
+
+Only imported resources can be deleted this way. Provisioned resources belong to the deployment that created them — remove those with `mass instance destroy`.
+
+## Usage
+
+```bash
+mass resource delete <resource-id> [flags]
+```
+
+## Flags
+
+- `-f, --force` — skip the confirmation prompt
+
+## Examples
+
+```bash
+# Delete an imported resource, confirming at the prompt
+mass resource delete 12345678-1234-1234-1234-123456789012
+
+# Skip the confirmation prompt
+mass resource delete 12345678-1234-1234-1234-123456789012 --force
+```
+
+
 ```
 mass resource delete [resource-id] [flags]
-```
-
-### Examples
-
-```
-  # Delete an imported resource
-  mass resource delete 12345678-1234-1234-1234-123456789012
-
-  # Skip the confirmation prompt
-  mass resource delete 12345678-1234-1234-1234-123456789012 --force
 ```
 
 ### Options

--- a/docs/generated/mass_resource_download.md
+++ b/docs/generated/mass_resource_download.md
@@ -60,17 +60,6 @@ mass resource download 12345678-1234-1234-1234-123456789012 --format json
 mass resource download [resource-id] [flags]
 ```
 
-### Examples
-
-```
-  # Download resource using UUID (imported resources)
-  mass resource download 12345678-1234-1234-1234-123456789012
-
-  # Download resource using friendly slug (provisioned resources)
-  mass resource download api-prod-database-connection
-  mass resource download network-useast1-vpc-network -f yaml
-```
-
 ### Options
 
 ```

--- a/docs/generated/mass_resource_get.md
+++ b/docs/generated/mass_resource_get.md
@@ -60,17 +60,6 @@ mass resource get api-prod-grpcapi-host -o json
 mass resource get [resource-id] [flags]
 ```
 
-### Examples
-
-```
-  # Get resource using UUID (imported resources)
-  mass resource get 12345678-1234-1234-1234-123456789012
-
-  # Get resource using friendly slug (provisioned resources)
-  mass resource get api-prod-database-connection
-  mass resource get api-prod-grpcapi-host -o json
-```
-
 ### Options
 
 ```

--- a/docs/generated/mass_resource_grant.md
+++ b/docs/generated/mass_resource_grant.md
@@ -1,0 +1,46 @@
+---
+id: mass_resource_grant.md
+slug: /cli/commands/mass_resource_grant
+title: Mass Resource Grant
+sidebar_label: Mass Resource Grant
+---
+## mass resource grant
+
+Manage sharing grants on a resource
+
+### Synopsis
+
+# Resource Grants
+
+Manages the sharing grants on a resource.
+
+A grant says "this resource is shared as `<action>`, to recipient environments matching `<conditions>`." Without a grant, a resource is visible only where it was created.
+
+Grants are immutable. To change an action or its conditions, delete the grant and create a replacement.
+
+## Usage
+
+```bash
+mass resource grant create <resource-id> [flags]
+mass resource grant list <resource-id> [flags]
+mass resource grant delete <grant-id>
+```
+
+## Notes
+
+- Creating or deleting a grant requires the `resource:grant` action on the resource.
+- Recipients are matched on **environment** attributes. Repository grants match on project attributes instead — see `mass repository grant`.
+
+
+### Options
+
+```
+  -h, --help   help for grant
+```
+
+### SEE ALSO
+
+* [mass resource](/cli/commands/mass_resource)	 - Manage resources
+* [mass resource grant create](/cli/commands/mass_resource_grant_create)	 - Share a resource with recipient environments
+* [mass resource grant delete](/cli/commands/mass_resource_grant_delete)	 - Revoke a sharing grant by id
+* [mass resource grant list](/cli/commands/mass_resource_grant_list)	 - List the sharing grants on a resource

--- a/docs/generated/mass_resource_grant_create.md
+++ b/docs/generated/mass_resource_grant_create.md
@@ -1,0 +1,89 @@
+---
+id: mass_resource_grant_create.md
+slug: /cli/commands/mass_resource_grant_create
+title: Mass Resource Grant Create
+sidebar_label: Mass Resource Grant Create
+---
+## mass resource grant create
+
+Share a resource with recipient environments
+
+### Synopsis
+
+# Create Resource Grant
+
+Shares a resource with recipient environments, so they can export it.
+
+Recipients are chosen by matching **environment** attributes. You must say who the recipients are: either name conditions with `--condition` / `--conditions-file`, or share with the whole organization with `--all-environments`. Leaving it unstated is an error rather than a silent org-wide grant.
+
+## Usage
+
+```bash
+mass resource grant create <resource-id> [flags]
+```
+
+## Flags
+
+- `--condition` — a recipient environment attribute condition, `key=value`. Repeat the same key to accept a set of values; write `key=*` to accept any value as long as the attribute is set.
+- `--conditions-file` — read conditions from a JSON file instead
+- `--all-environments` — share with every environment in the organization
+- `--action` — the action to grant. Defaults to `resource:export`, currently the only grantable resource action.
+
+`--condition`, `--conditions-file`, and `--all-environments` are mutually exclusive.
+
+## Examples
+
+```bash
+# Share with environments whose stage attribute is dev or staging
+mass resource grant create api-prod-database-connection \
+  --condition stage=dev \
+  --condition stage=staging
+
+# Share with environments that have any region attribute set
+mass resource grant create api-prod-database-connection --condition 'region=*'
+
+# Share with every environment in the organization
+mass resource grant create api-prod-database-connection --all-environments
+
+# Read conditions from a JSON file
+mass resource grant create api-prod-database-connection --conditions-file ./conditions.json
+```
+
+## Conditions file format
+
+One JSON object, shaped like a grant's `recipientConditions` in `mass resource grant list -o json`. Values are either `"*"` for the per-key wildcard or an array of accepted values:
+
+```json
+{
+  "stage": ["dev", "staging"],
+  "region": "*"
+}
+```
+
+A file holding `null` or `{}` is rejected — use `--all-environments` to share organization-wide, so the broadest grant is always explicit.
+
+## Notes
+
+- The `<resource-id>` is a UUID for imported resources, or a friendly slug for provisioned ones.
+- Quote `key=*` so your shell does not expand the `*`.
+- A comma is an ordinary character in a condition value. Unlike `--attributes`, it does not separate pairs.
+- Grants are immutable; to change one, delete it and create a replacement.
+
+
+```
+mass resource grant create <resource-id> [flags]
+```
+
+### Options
+
+```
+      --action string            Action to grant (default resource:export)
+      --all-environments         Share with every environment in the organization
+      --condition stringArray    Recipient environment attribute condition; repeat a key to accept a set of values, or write key=* to accept any value
+      --conditions-file string   Read recipient conditions from a JSON file
+  -h, --help                     help for create
+```
+
+### SEE ALSO
+
+* [mass resource grant](/cli/commands/mass_resource_grant)	 - Manage sharing grants on a resource

--- a/docs/generated/mass_resource_grant_delete.md
+++ b/docs/generated/mass_resource_grant_delete.md
@@ -1,0 +1,49 @@
+---
+id: mass_resource_grant_delete.md
+slug: /cli/commands/mass_resource_grant_delete
+title: Mass Resource Grant Delete
+sidebar_label: Mass Resource Grant Delete
+---
+## mass resource grant delete
+
+Revoke a sharing grant by id
+
+### Synopsis
+
+# Delete Resource Grant
+
+Revokes a sharing grant by id. Environments that qualified only through this grant immediately lose access to the resource.
+
+## Usage
+
+```bash
+mass resource grant delete <grant-id>
+```
+
+## Examples
+
+```bash
+# Find the grant id, then revoke it
+mass resource grant list api-prod-database-connection
+mass resource grant delete 4f2a9c18-1f0e-4a5c-9a3e-2b6d7c8e9f10
+```
+
+## Notes
+
+- Grants are immutable, so changing one means deleting it and creating a replacement.
+- This does not prompt for confirmation. A revoked grant can be re-created with `mass resource grant create`.
+
+
+```
+mass resource grant delete <grant-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for delete
+```
+
+### SEE ALSO
+
+* [mass resource grant](/cli/commands/mass_resource_grant)	 - Manage sharing grants on a resource

--- a/docs/generated/mass_resource_grant_list.md
+++ b/docs/generated/mass_resource_grant_list.md
@@ -1,0 +1,58 @@
+---
+id: mass_resource_grant_list.md
+slug: /cli/commands/mass_resource_grant_list
+title: Mass Resource Grant List
+sidebar_label: Mass Resource Grant List
+---
+## mass resource grant list
+
+List the sharing grants on a resource
+
+### Synopsis
+
+# List Resource Grants
+
+Lists the sharing grants authored on a resource — what it is shared as, and which recipient environments qualify.
+
+If you can see a resource you can see all of its grants; they are publisher-side metadata rather than being visibility-gated themselves.
+
+## Usage
+
+```bash
+mass resource grant list <resource-id> [flags]
+```
+
+## Flags
+
+- `-o, --output` — output format: `table` or `json`
+
+## Examples
+
+```bash
+# List the grants on a resource
+mass resource grant list api-prod-database-connection
+
+# As JSON, for scripting
+mass resource grant list api-prod-database-connection -o json
+```
+
+## Notes
+
+- The `Recipients` column reads `everyone` for an organization-wide grant, `key=*` for a per-key wildcard, and `key=a|b` for a closed set.
+- The `ID` column is what `mass resource grant delete` takes.
+
+
+```
+mass resource grant list <resource-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for list
+  -o, --output string   Output format (table, json) (default "table")
+```
+
+### SEE ALSO
+
+* [mass resource grant](/cli/commands/mass_resource_grant)	 - Manage sharing grants on a resource

--- a/docs/generated/mass_resource_list.md
+++ b/docs/generated/mass_resource_list.md
@@ -55,18 +55,6 @@ mass resource list --environment ecomm-prod -o json
 mass resource list [flags]
 ```
 
-### Examples
-
-```
-  # List all resources
-  mass resource list
-
-  # Search and filter
-  mass resource list --search database
-  mass resource list --type aws-iam-role --origin provisioned
-  mass resource list --environment ecomm-prod -o json
-```
-
 ### Options
 
 ```

--- a/docs/generated/mass_resource_update.md
+++ b/docs/generated/mass_resource_update.md
@@ -17,23 +17,21 @@ Update the payload of an imported resource. This command only works for imported
 ## Examples
 
 ```shell
-mass resource update <resource-id> -f <file>
-mass resource update <resource-id> -f <file> -n <new-name>
+# Update the resource payload
+mass resource update 12345678-1234-1234-1234-123456789012 -f resource.json
+
+# Update the payload and rename the resource
+mass resource update 12345678-1234-1234-1234-123456789012 -f resource.json -n new-name
 ```
+
+## Options
+
+- `--file, -f`: Path to the JSON file holding the new payload
+- `--name, -n`: New name for the resource
 
 
 ```
 mass resource update [resource-id] [flags]
-```
-
-### Examples
-
-```
-  # Update resource payload
-  mass resource update 12345678-1234-1234-1234-123456789012 -f resource.json
-
-  # Update resource payload and rename
-  mass resource update 12345678-1234-1234-1234-123456789012 -f resource.json -n new-name
 ```
 
 ### Options

--- a/docs/helpdocs/bundle/create.md
+++ b/docs/helpdocs/bundle/create.md
@@ -1,0 +1,28 @@
+# Create Bundle Repository
+
+Creates an empty bundle OCI repository in your organization's catalog. The repository holds published versions of a bundle; create it before the first `mass bundle publish`.
+
+## Usage
+
+```bash
+mass bundle create <name> [flags]
+```
+
+## Flags
+
+- `-a, --attributes` — custom attributes for ABAC (repeat or comma-separate)
+
+## Examples
+
+```bash
+# Create a repository for an Aurora Postgres bundle
+mass bundle create aws-aurora-postgres
+
+# Tag it with attributes policies and grants can match on
+mass bundle create aws-aurora-postgres -a owner=data,service=database
+```
+
+## Notes
+
+- This is `mass repository create --type bundle` with the type filled in.
+- Share the repository with other projects using `mass repository grant create`.

--- a/docs/helpdocs/component/update.md
+++ b/docs/helpdocs/component/update.md
@@ -1,0 +1,30 @@
+# Update Component
+
+Updates a component's display name, description, or custom attributes.
+
+Attributes are replaced wholesale rather than merged, so pass every attribute you want to keep.
+
+## Usage
+
+```bash
+mass component update <component-id> [flags]
+```
+
+## Flags
+
+- `-n, --name` — new display name
+- `-d, --description` — new description
+- `-a, --attributes` — replacement custom attributes (repeat or comma-separate)
+
+## Examples
+
+```bash
+# Rename a component
+mass component update ecomm-db --name "Primary DB"
+
+# Rename and retag it in one call
+mass component update ecomm-db --name "Primary DB" -a priority=high
+
+# Replace the full attribute set
+mass component update ecomm-db -a priority=high,cost-center=engineering
+```

--- a/docs/helpdocs/environment/deploy.md
+++ b/docs/helpdocs/environment/deploy.md
@@ -33,4 +33,7 @@ mass environment deploy ecomm-staging
 # Deploy a freshly-forked preview env.
 mass environment fork ecomm-production pr42 --copy-environment-defaults
 mass environment deploy ecomm-pr42
+
+# Stream every instance's logs until the rollout finishes.
+mass environment deploy ecomm-staging --follow
 ```

--- a/docs/helpdocs/instance/destroy.md
+++ b/docs/helpdocs/instance/destroy.md
@@ -1,0 +1,30 @@
+# Destroy Instance
+
+Destroys (decommissions) an instance. This permanently deletes the instance and all the resources it provisioned.
+
+## Usage
+
+```bash
+mass instance destroy <project>-<env>-<manifest> [flags]
+```
+
+## Flags
+
+- `-m, --message` — add a message when decommissioning
+- `-f, --force` — skip the confirmation prompt
+- `-p, --params` — path to a params json, tfvars or yaml file; `-` reads stdin
+- `-P, --patch` — patch the last deployed configuration with a JQ expression (repeatable)
+- `--follow` — stream the deployment's logs to stdout until it completes
+
+## Examples
+
+```bash
+# Destroy an instance, confirming at the prompt
+mass instance destroy api-prod-db
+
+# Skip the prompt, for scripted teardown
+mass instance destroy api-prod-db --force
+
+# Destroy and watch the logs until it finishes
+mass instance destroy api-prod-db --force --follow
+```

--- a/docs/helpdocs/repository/grant-create.md
+++ b/docs/helpdocs/repository/grant-create.md
@@ -1,0 +1,57 @@
+# Create Repository Grant
+
+Shares an OCI repository with recipient projects, so they can pull it.
+
+Recipients are chosen by matching **project** attributes. You must say who the recipients are: either name conditions with `--condition` / `--conditions-file`, or share with the whole organization with `--all-projects`. Leaving it unstated is an error rather than a silent org-wide grant.
+
+## Usage
+
+```bash
+mass repository grant create <name> [flags]
+```
+
+## Flags
+
+- `--condition` — a recipient project attribute condition, `key=value`. Repeat the same key to accept a set of values; write `key=*` to accept any value as long as the attribute is set.
+- `--conditions-file` — read conditions from a JSON file instead
+- `--all-projects` — share with every project in the organization
+- `--action` — the action to grant. Defaults to `repo:pull`, currently the only grantable repository action.
+
+`--condition`, `--conditions-file`, and `--all-projects` are mutually exclusive.
+
+## Examples
+
+```bash
+# Share with projects whose team attribute is platform or data
+mass repository grant create aws-aurora-postgres \
+  --condition team=platform \
+  --condition team=data
+
+# Share with projects that have any region attribute set
+mass repository grant create aws-aurora-postgres --condition 'region=*'
+
+# Share with every project in the organization
+mass repository grant create aws-aurora-postgres --all-projects
+
+# Read conditions from a JSON file
+mass repository grant create aws-aurora-postgres --conditions-file ./conditions.json
+```
+
+## Conditions file format
+
+One JSON object, shaped like a grant's `recipientConditions` in `mass repository grant list -o json`. Values are either `"*"` for the per-key wildcard or an array of accepted values:
+
+```json
+{
+  "team": ["platform", "data"],
+  "region": "*"
+}
+```
+
+A file holding `null` or `{}` is rejected — use `--all-projects` to share organization-wide, so the broadest grant is always explicit.
+
+## Notes
+
+- Quote `key=*` so your shell does not expand the `*`.
+- A comma is an ordinary character in a condition value. Unlike `--attributes`, it does not separate pairs.
+- Grants are immutable; to change one, delete it and create a replacement.

--- a/docs/helpdocs/repository/grant-delete.md
+++ b/docs/helpdocs/repository/grant-delete.md
@@ -1,0 +1,22 @@
+# Delete Repository Grant
+
+Revokes a sharing grant by id. Recipients that qualified only through this grant immediately lose access to the repository.
+
+## Usage
+
+```bash
+mass repository grant delete <grant-id>
+```
+
+## Examples
+
+```bash
+# Find the grant id, then revoke it
+mass repository grant list aws-aurora-postgres
+mass repository grant delete 4f2a9c18-1f0e-4a5c-9a3e-2b6d7c8e9f10
+```
+
+## Notes
+
+- Grants are immutable, so changing one means deleting it and creating a replacement.
+- This does not prompt for confirmation. A revoked grant can be re-created with `mass repository grant create`.

--- a/docs/helpdocs/repository/grant-list.md
+++ b/docs/helpdocs/repository/grant-list.md
@@ -1,0 +1,30 @@
+# List Repository Grants
+
+Lists the sharing grants authored on an OCI repository — what it is shared as, and which recipient projects qualify.
+
+If you can see a repository you can see all of its grants; they are publisher-side metadata rather than being visibility-gated themselves.
+
+## Usage
+
+```bash
+mass repository grant list <name> [flags]
+```
+
+## Flags
+
+- `-o, --output` — output format: `table` or `json`
+
+## Examples
+
+```bash
+# List the grants on a repository
+mass repository grant list aws-aurora-postgres
+
+# As JSON, for scripting
+mass repository grant list aws-aurora-postgres -o json
+```
+
+## Notes
+
+- The `Recipients` column reads `everyone` for an organization-wide grant, `key=*` for a per-key wildcard, and `key=a|b` for a closed set.
+- The `ID` column is what `mass repository grant delete` takes.

--- a/docs/helpdocs/repository/grant.md
+++ b/docs/helpdocs/repository/grant.md
@@ -1,0 +1,20 @@
+# Repository Grants
+
+Manages the sharing grants on an OCI repository.
+
+A grant says "this repository is shared as `<action>`, to recipient projects matching `<conditions>`." Without a grant, a repository is visible only where it was published.
+
+Grants are immutable. To change an action or its conditions, delete the grant and create a replacement.
+
+## Usage
+
+```bash
+mass repository grant create <name> [flags]
+mass repository grant list <name> [flags]
+mass repository grant delete <grant-id>
+```
+
+## Notes
+
+- Creating or deleting a grant requires the `repo:grant` action on the repository.
+- Recipients are matched on **project** attributes. Resource grants match on environment attributes instead — see `mass resource grant`.

--- a/docs/helpdocs/resource/delete.md
+++ b/docs/helpdocs/resource/delete.md
@@ -1,0 +1,25 @@
+# Delete Resource
+
+Deletes an imported resource from your organization.
+
+Only imported resources can be deleted this way. Provisioned resources belong to the deployment that created them — remove those with `mass instance destroy`.
+
+## Usage
+
+```bash
+mass resource delete <resource-id> [flags]
+```
+
+## Flags
+
+- `-f, --force` — skip the confirmation prompt
+
+## Examples
+
+```bash
+# Delete an imported resource, confirming at the prompt
+mass resource delete 12345678-1234-1234-1234-123456789012
+
+# Skip the confirmation prompt
+mass resource delete 12345678-1234-1234-1234-123456789012 --force
+```

--- a/docs/helpdocs/resource/grant-create.md
+++ b/docs/helpdocs/resource/grant-create.md
@@ -1,0 +1,58 @@
+# Create Resource Grant
+
+Shares a resource with recipient environments, so they can export it.
+
+Recipients are chosen by matching **environment** attributes. You must say who the recipients are: either name conditions with `--condition` / `--conditions-file`, or share with the whole organization with `--all-environments`. Leaving it unstated is an error rather than a silent org-wide grant.
+
+## Usage
+
+```bash
+mass resource grant create <resource-id> [flags]
+```
+
+## Flags
+
+- `--condition` — a recipient environment attribute condition, `key=value`. Repeat the same key to accept a set of values; write `key=*` to accept any value as long as the attribute is set.
+- `--conditions-file` — read conditions from a JSON file instead
+- `--all-environments` — share with every environment in the organization
+- `--action` — the action to grant. Defaults to `resource:export`, currently the only grantable resource action.
+
+`--condition`, `--conditions-file`, and `--all-environments` are mutually exclusive.
+
+## Examples
+
+```bash
+# Share with environments whose stage attribute is dev or staging
+mass resource grant create api-prod-database-connection \
+  --condition stage=dev \
+  --condition stage=staging
+
+# Share with environments that have any region attribute set
+mass resource grant create api-prod-database-connection --condition 'region=*'
+
+# Share with every environment in the organization
+mass resource grant create api-prod-database-connection --all-environments
+
+# Read conditions from a JSON file
+mass resource grant create api-prod-database-connection --conditions-file ./conditions.json
+```
+
+## Conditions file format
+
+One JSON object, shaped like a grant's `recipientConditions` in `mass resource grant list -o json`. Values are either `"*"` for the per-key wildcard or an array of accepted values:
+
+```json
+{
+  "stage": ["dev", "staging"],
+  "region": "*"
+}
+```
+
+A file holding `null` or `{}` is rejected — use `--all-environments` to share organization-wide, so the broadest grant is always explicit.
+
+## Notes
+
+- The `<resource-id>` is a UUID for imported resources, or a friendly slug for provisioned ones.
+- Quote `key=*` so your shell does not expand the `*`.
+- A comma is an ordinary character in a condition value. Unlike `--attributes`, it does not separate pairs.
+- Grants are immutable; to change one, delete it and create a replacement.

--- a/docs/helpdocs/resource/grant-delete.md
+++ b/docs/helpdocs/resource/grant-delete.md
@@ -1,0 +1,22 @@
+# Delete Resource Grant
+
+Revokes a sharing grant by id. Environments that qualified only through this grant immediately lose access to the resource.
+
+## Usage
+
+```bash
+mass resource grant delete <grant-id>
+```
+
+## Examples
+
+```bash
+# Find the grant id, then revoke it
+mass resource grant list api-prod-database-connection
+mass resource grant delete 4f2a9c18-1f0e-4a5c-9a3e-2b6d7c8e9f10
+```
+
+## Notes
+
+- Grants are immutable, so changing one means deleting it and creating a replacement.
+- This does not prompt for confirmation. A revoked grant can be re-created with `mass resource grant create`.

--- a/docs/helpdocs/resource/grant-list.md
+++ b/docs/helpdocs/resource/grant-list.md
@@ -1,0 +1,30 @@
+# List Resource Grants
+
+Lists the sharing grants authored on a resource — what it is shared as, and which recipient environments qualify.
+
+If you can see a resource you can see all of its grants; they are publisher-side metadata rather than being visibility-gated themselves.
+
+## Usage
+
+```bash
+mass resource grant list <resource-id> [flags]
+```
+
+## Flags
+
+- `-o, --output` — output format: `table` or `json`
+
+## Examples
+
+```bash
+# List the grants on a resource
+mass resource grant list api-prod-database-connection
+
+# As JSON, for scripting
+mass resource grant list api-prod-database-connection -o json
+```
+
+## Notes
+
+- The `Recipients` column reads `everyone` for an organization-wide grant, `key=*` for a per-key wildcard, and `key=a|b` for a closed set.
+- The `ID` column is what `mass resource grant delete` takes.

--- a/docs/helpdocs/resource/grant.md
+++ b/docs/helpdocs/resource/grant.md
@@ -1,0 +1,20 @@
+# Resource Grants
+
+Manages the sharing grants on a resource.
+
+A grant says "this resource is shared as `<action>`, to recipient environments matching `<conditions>`." Without a grant, a resource is visible only where it was created.
+
+Grants are immutable. To change an action or its conditions, delete the grant and create a replacement.
+
+## Usage
+
+```bash
+mass resource grant create <resource-id> [flags]
+mass resource grant list <resource-id> [flags]
+mass resource grant delete <grant-id>
+```
+
+## Notes
+
+- Creating or deleting a grant requires the `resource:grant` action on the resource.
+- Recipients are matched on **environment** attributes. Repository grants match on project attributes instead — see `mass repository grant`.

--- a/docs/helpdocs/resource/update.md
+++ b/docs/helpdocs/resource/update.md
@@ -5,6 +5,14 @@ Update the payload of an imported resource. This command only works for imported
 ## Examples
 
 ```shell
-mass resource update <resource-id> -f <file>
-mass resource update <resource-id> -f <file> -n <new-name>
+# Update the resource payload
+mass resource update 12345678-1234-1234-1234-123456789012 -f resource.json
+
+# Update the payload and rename the resource
+mass resource update 12345678-1234-1234-1234-123456789012 -f resource.json -n new-name
 ```
+
+## Options
+
+- `--file, -f`: Path to the JSON file holding the new payload
+- `--name, -n`: New name for the resource

--- a/internal/commands/grants/actions.go
+++ b/internal/commands/grants/actions.go
@@ -1,0 +1,38 @@
+package grants
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+)
+
+// The read path returns actions that cannot be granted (repo:view, repo:push,
+// resource:view), so these gate --action only.
+const (
+	ActionRepoPull       = "repo:pull"
+	ActionResourceExport = "resource:export"
+)
+
+var (
+	grantableRepoActions     = []string{ActionRepoPull}
+	grantableResourceActions = []string{ActionResourceExport}
+)
+
+func ResolveRepoAction(action string) (string, error) {
+	return resolveAction(action, ActionRepoPull, grantableRepoActions)
+}
+
+func ResolveResourceAction(action string) (string, error) {
+	return resolveAction(action, ActionResourceExport, grantableResourceActions)
+}
+
+func resolveAction(action, fallback string, grantable []string) (string, error) {
+	normalized := strings.ToLower(strings.TrimSpace(action))
+	if normalized == "" {
+		return fallback, nil
+	}
+	if slices.Contains(grantable, normalized) {
+		return normalized, nil
+	}
+	return "", fmt.Errorf("unknown action %q (valid: %s)", action, strings.Join(grantable, ", "))
+}

--- a/internal/commands/grants/actions_test.go
+++ b/internal/commands/grants/actions_test.go
@@ -1,0 +1,67 @@
+package grants_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/massdriver-cloud/mass/internal/commands/grants"
+)
+
+func TestResolveActionDefaults(t *testing.T) {
+	repoAction, err := grants.ResolveRepoAction("")
+	if err != nil {
+		t.Fatalf("ResolveRepoAction returned error: %v", err)
+	}
+	if repoAction != grants.ActionRepoPull {
+		t.Errorf("ResolveRepoAction(\"\") = %q, want %q", repoAction, grants.ActionRepoPull)
+	}
+
+	resourceAction, err := grants.ResolveResourceAction("")
+	if err != nil {
+		t.Fatalf("ResolveResourceAction returned error: %v", err)
+	}
+	if resourceAction != grants.ActionResourceExport {
+		t.Errorf("ResolveResourceAction(\"\") = %q, want %q", resourceAction, grants.ActionResourceExport)
+	}
+}
+
+func TestResolveActionNormalizes(t *testing.T) {
+	for _, input := range []string{"repo:pull", "REPO:PULL", "  Repo:Pull  "} {
+		t.Run(input, func(t *testing.T) {
+			got, err := grants.ResolveRepoAction(input)
+			if err != nil {
+				t.Fatalf("ResolveRepoAction(%q) returned error: %v", input, err)
+			}
+			if got != grants.ActionRepoPull {
+				t.Errorf("ResolveRepoAction(%q) = %q, want %q", input, got, grants.ActionRepoPull)
+			}
+		})
+	}
+}
+
+func TestResolveActionRejectsUngrantable(t *testing.T) {
+	cases := []struct {
+		name    string
+		resolve func(string) (string, error)
+		action  string
+	}{
+		{"repo view is read-only", grants.ResolveRepoAction, "repo:view"},
+		{"repo push is not a sharing concern", grants.ResolveRepoAction, "repo:push"},
+		{"resource action on a repo", grants.ResolveRepoAction, grants.ActionResourceExport},
+		{"resource view is read-only", grants.ResolveResourceAction, "resource:view"},
+		{"repo action on a resource", grants.ResolveResourceAction, grants.ActionRepoPull},
+		{"nonsense", grants.ResolveRepoAction, "repo:destroy"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tc.resolve(tc.action)
+			if err == nil {
+				t.Fatalf("resolving %q succeeded, wanted error", tc.action)
+			}
+			if !strings.Contains(err.Error(), "unknown action") {
+				t.Errorf("error = %q, want it to contain %q", err, "unknown action")
+			}
+		})
+	}
+}

--- a/internal/commands/grants/conditions.go
+++ b/internal/commands/grants/conditions.go
@@ -1,0 +1,138 @@
+package grants
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/platform/types"
+)
+
+const wildcardValue = "*"
+
+// Repeating a key unions its values; only allFlag yields nil, the org-wide
+// wildcard.
+func ResolveConditions(pairs []string, file string, all bool, allFlag string) (types.PolicyConditions, error) {
+	supplied := 0
+	for _, given := range []bool{len(pairs) > 0, file != "", all} {
+		if given {
+			supplied++
+		}
+	}
+
+	switch {
+	case supplied == 0:
+		return nil, fmt.Errorf("specify recipient conditions with --condition or --conditions-file, or share with your whole organization using --%s", allFlag)
+	case supplied > 1:
+		return nil, fmt.Errorf("--condition, --conditions-file, and --%s are mutually exclusive", allFlag)
+	case all:
+		//nolint:nilnil // nil conditions is the org-wide wildcard, not a missing value
+		return nil, nil
+	case file != "":
+		return ParseConditionsFile(file, allFlag)
+	default:
+		return ParseConditions(pairs)
+	}
+}
+
+func ParseConditions(pairs []string) (types.PolicyConditions, error) {
+	if len(pairs) == 0 {
+		return nil, errors.New("no conditions given")
+	}
+
+	conditions := types.PolicyConditions{}
+	wildcards := map[string]bool{}
+
+	for _, pair := range pairs {
+		key, value, found := strings.Cut(pair, "=")
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+
+		switch {
+		case !found:
+			return nil, fmt.Errorf("condition %q must be formatted as key=value", pair)
+		case key == "":
+			return nil, fmt.Errorf("condition %q has an empty attribute name", pair)
+		case value == "":
+			return nil, fmt.Errorf("condition %q has an empty value; write %s=%s to accept any value", pair, key, wildcardValue)
+		}
+
+		if value == wildcardValue {
+			if len(conditions[key]) > 0 {
+				return nil, conflictError(key)
+			}
+			wildcards[key] = true
+			conditions[key] = nil
+			continue
+		}
+		if wildcards[key] {
+			return nil, conflictError(key)
+		}
+		if !slices.Contains(conditions[key], value) {
+			conditions[key] = append(conditions[key], value)
+		}
+	}
+
+	return conditions, nil
+}
+
+func ParseConditionsFile(path, allFlag string) (types.PolicyConditions, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading conditions file: %w", err)
+	}
+
+	var conditions types.PolicyConditions
+	if unmarshalErr := json.Unmarshal(data, &conditions); unmarshalErr != nil {
+		return nil, fmt.Errorf("parsing conditions file %s: %w", path, unmarshalErr)
+	}
+
+	// `null` and `{}` decode to the org-wide wildcard, routing around allFlag.
+	if len(conditions) == 0 {
+		return nil, fmt.Errorf("conditions file %s describes no conditions; share with your whole organization using --%s", path, allFlag)
+	}
+	for key, values := range conditions {
+		if strings.TrimSpace(key) == "" {
+			return nil, fmt.Errorf("conditions file %s has an empty attribute name", path)
+		}
+		for i, value := range values {
+			trimmed := strings.TrimSpace(value)
+			if trimmed == "" {
+				return nil, fmt.Errorf("conditions file %s has an empty value for %q; use %q to accept any value", path, key, wildcardValue)
+			}
+			values[i] = trimmed
+		}
+	}
+
+	return conditions, nil
+}
+
+func FormatConditions(conditions types.PolicyConditions) string {
+	if len(conditions) == 0 {
+		return "everyone"
+	}
+
+	keys := make([]string, 0, len(conditions))
+	for key := range conditions {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		if len(conditions[key]) == 0 {
+			parts = append(parts, key+"="+wildcardValue)
+			continue
+		}
+		parts = append(parts, key+"="+strings.Join(conditions[key], "|"))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func conflictError(key string) error {
+	return fmt.Errorf("condition %q mixes %s=%s with specific values; use one or the other", key, key, wildcardValue)
+}

--- a/internal/commands/grants/conditions_test.go
+++ b/internal/commands/grants/conditions_test.go
@@ -1,0 +1,295 @@
+package grants_test
+
+import (
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/massdriver-cloud/mass/internal/commands/grants"
+	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/platform/types"
+)
+
+func TestParseConditions(t *testing.T) {
+	cases := []struct {
+		name  string
+		pairs []string
+		want  types.PolicyConditions
+	}{
+		{
+			name:  "single value",
+			pairs: []string{"team=platform"},
+			want:  types.PolicyConditions{"team": {"platform"}},
+		},
+		{
+			name:  "repeated key unions into a closed set",
+			pairs: []string{"team=platform", "team=data"},
+			want:  types.PolicyConditions{"team": {"platform", "data"}},
+		},
+		{
+			name:  "repeated identical value is deduped",
+			pairs: []string{"team=platform", "team=platform"},
+			want:  types.PolicyConditions{"team": {"platform"}},
+		},
+		{
+			name:  "star is the per-key wildcard",
+			pairs: []string{"region=*"},
+			want:  types.PolicyConditions{"region": nil},
+		},
+		{
+			name:  "distinct keys are independent",
+			pairs: []string{"team=platform", "region=*", "stage=prod"},
+			want:  types.PolicyConditions{"team": {"platform"}, "region": nil, "stage": {"prod"}},
+		},
+		{
+			name:  "value may contain an equals sign",
+			pairs: []string{"expr=a=b"},
+			want:  types.PolicyConditions{"expr": {"a=b"}},
+		},
+		{
+			// A comma splits pairs in --attributes; here it is just a character.
+			name:  "value may contain a comma",
+			pairs: []string{"team=platform,data"},
+			want:  types.PolicyConditions{"team": {"platform,data"}},
+		},
+		{
+			name:  "surrounding whitespace is trimmed",
+			pairs: []string{"  team  =  platform  "},
+			want:  types.PolicyConditions{"team": {"platform"}},
+		},
+		{
+			// Untrimmed this stores a literal " *", which matches no recipient.
+			name:  "spaced wildcard is still a wildcard",
+			pairs: []string{"region= *"},
+			want:  types.PolicyConditions{"region": nil},
+		},
+		{
+			name:  "inner whitespace is preserved",
+			pairs: []string{"team=platform team"},
+			want:  types.PolicyConditions{"team": {"platform team"}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := grants.ParseConditions(tc.pairs)
+			if err != nil {
+				t.Fatalf("ParseConditions(%v) returned error: %v", tc.pairs, err)
+			}
+			if !conditionsEqual(got, tc.want) {
+				t.Errorf("ParseConditions(%v) = %v, want %v", tc.pairs, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseConditionsErrors(t *testing.T) {
+	cases := []struct {
+		name      string
+		pairs     []string
+		wantError string
+	}{
+		{"no pairs", nil, "no conditions given"},
+		{"missing equals", []string{"team"}, "must be formatted as key=value"},
+		{"empty key", []string{"=platform"}, "empty attribute name"},
+		{"empty value", []string{"team="}, "empty value"},
+		{"whitespace-only value", []string{"team=   "}, "empty value"},
+		{"wildcard then specific", []string{"team=*", "team=platform"}, "use one or the other"},
+		{"specific then wildcard", []string{"team=platform", "team=*"}, "use one or the other"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := grants.ParseConditions(tc.pairs)
+			if err == nil {
+				t.Fatalf("ParseConditions(%v) succeeded, wanted error", tc.pairs)
+			}
+			if !strings.Contains(err.Error(), tc.wantError) {
+				t.Errorf("ParseConditions(%v) error = %q, want it to contain %q", tc.pairs, err, tc.wantError)
+			}
+		})
+	}
+}
+
+func TestParseConditionsRepeatedWildcard(t *testing.T) {
+	got, err := grants.ParseConditions([]string{"region=*", "region=*"})
+	if err != nil {
+		t.Fatalf("ParseConditions returned error: %v", err)
+	}
+	if !conditionsEqual(got, types.PolicyConditions{"region": nil}) {
+		t.Errorf("ParseConditions = %v, want region wildcard", got)
+	}
+}
+
+func TestResolveConditions(t *testing.T) {
+	conditions, err := grants.ResolveConditions([]string{"team=platform"}, "", false, "all-projects")
+	if err != nil {
+		t.Fatalf("ResolveConditions returned error: %v", err)
+	}
+	if !conditionsEqual(conditions, types.PolicyConditions{"team": {"platform"}}) {
+		t.Errorf("ResolveConditions = %v, want team=platform", conditions)
+	}
+}
+
+func TestResolveConditionsAllIsTheOnlyWildcard(t *testing.T) {
+	conditions, err := grants.ResolveConditions(nil, "", true, "all-projects")
+	if err != nil {
+		t.Fatalf("ResolveConditions returned error: %v", err)
+	}
+	if conditions != nil {
+		t.Errorf("ResolveConditions(all) = %v, want nil", conditions)
+	}
+}
+
+func TestResolveConditionsErrors(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "conditions.json")
+	if err := os.WriteFile(file, []byte(`{"team":["platform"]}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name      string
+		pairs     []string
+		file      string
+		all       bool
+		wantError string
+	}{
+		{"nothing given", nil, "", false, "--all-projects"},
+		{"pairs and file", []string{"team=platform"}, file, false, "mutually exclusive"},
+		{"pairs and all", []string{"team=platform"}, "", true, "mutually exclusive"},
+		{"file and all", nil, file, true, "mutually exclusive"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := grants.ResolveConditions(tc.pairs, tc.file, tc.all, "all-projects")
+			if err == nil {
+				t.Fatal("ResolveConditions succeeded, wanted error")
+			}
+			if !strings.Contains(err.Error(), tc.wantError) {
+				t.Errorf("ResolveConditions error = %q, want it to contain %q", err, tc.wantError)
+			}
+		})
+	}
+}
+
+func TestParseConditionsFile(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "conditions.json")
+	if err := os.WriteFile(file, []byte(`{"team":["platform"," data "],"region":"*"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := grants.ParseConditionsFile(file, "all-projects")
+	if err != nil {
+		t.Fatalf("ParseConditionsFile returned error: %v", err)
+	}
+	want := types.PolicyConditions{"team": {"platform", "data"}, "region": nil}
+	if !conditionsEqual(got, want) {
+		t.Errorf("ParseConditionsFile = %v, want %v", got, want)
+	}
+}
+
+func TestParseConditionsFileRejectsWildcard(t *testing.T) {
+	dir := t.TempDir()
+
+	for _, body := range []string{"null", "{}"} {
+		t.Run(body, func(t *testing.T) {
+			file := filepath.Join(dir, "wildcard.json")
+			if err := os.WriteFile(file, []byte(body), 0600); err != nil {
+				t.Fatal(err)
+			}
+			_, err := grants.ParseConditionsFile(file, "all-projects")
+			if err == nil {
+				t.Fatal("ParseConditionsFile succeeded, wanted error")
+			}
+			if !strings.Contains(err.Error(), "--all-projects") {
+				t.Errorf("error = %q, want it to name --all-projects", err)
+			}
+		})
+	}
+}
+
+func TestParseConditionsFileErrors(t *testing.T) {
+	dir := t.TempDir()
+
+	malformed := filepath.Join(dir, "malformed.json")
+	if err := os.WriteFile(malformed, []byte("{not json"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	emptyKey := filepath.Join(dir, "empty-key.json")
+	if err := os.WriteFile(emptyKey, []byte(`{"":["platform"]}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	emptyValue := filepath.Join(dir, "empty-value.json")
+	if err := os.WriteFile(emptyValue, []byte(`{"team":["  "]}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name      string
+		path      string
+		wantError string
+	}{
+		{"missing file", filepath.Join(dir, "absent.json"), "reading conditions file"},
+		{"malformed json", malformed, "parsing conditions file"},
+		{"empty attribute name", emptyKey, "empty attribute name"},
+		{"empty value", emptyValue, "empty value"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := grants.ParseConditionsFile(tc.path, "all-projects")
+			if err == nil {
+				t.Fatal("ParseConditionsFile succeeded, wanted error")
+			}
+			if !strings.Contains(err.Error(), tc.wantError) {
+				t.Errorf("error = %q, want it to contain %q", err, tc.wantError)
+			}
+		})
+	}
+}
+
+func TestFormatConditions(t *testing.T) {
+	cases := []struct {
+		name       string
+		conditions types.PolicyConditions
+		want       string
+	}{
+		{"nil is org-wide", nil, "everyone"},
+		{"empty map is org-wide", types.PolicyConditions{}, "everyone"},
+		{"per-key wildcard", types.PolicyConditions{"region": nil}, "region=*"},
+		{"empty slice is a wildcard too", types.PolicyConditions{"region": {}}, "region=*"},
+		{"closed set", types.PolicyConditions{"team": {"platform", "data"}}, "team=platform|data"},
+		{
+			name:       "keys are sorted for stable output",
+			conditions: types.PolicyConditions{"team": {"platform"}, "region": nil, "stage": {"prod"}},
+			want:       "region=*, stage=prod, team=platform",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := grants.FormatConditions(tc.conditions); got != tc.want {
+				t.Errorf("FormatConditions(%v) = %q, want %q", tc.conditions, got, tc.want)
+			}
+		})
+	}
+}
+
+// A nil and an empty value slice are the same per-key wildcard.
+func conditionsEqual(got, want types.PolicyConditions) bool {
+	if (got == nil) != (want == nil) || len(got) != len(want) {
+		return false
+	}
+	for key := range maps.Keys(want) {
+		gotValues, ok := got[key]
+		if !ok || !slices.Equal(gotValues, want[key]) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/commands/grants/grants.go
+++ b/internal/commands/grants/grants.go
@@ -1,0 +1,67 @@
+// Package grants holds the logic behind `mass repository grant` and
+// `mass resource grant`.
+package grants
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"iter"
+	"os"
+	"regexp"
+
+	"github.com/massdriver-cloud/mass/internal/cli"
+	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/gql"
+	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/platform/types"
+)
+
+// out doubles as the interactivity signal: a TTY gets the pager, anything
+// else a streamed table.
+func Render(seq iter.Seq2[types.Grant, error], output string, out *os.File) error {
+	switch output {
+	case "json":
+		items, collectErr := types.Collect(seq)
+		if collectErr != nil {
+			return collectErr
+		}
+		jsonBytes, marshalErr := json.MarshalIndent(items, "", "  ")
+		if marshalErr != nil {
+			return fmt.Errorf("failed to marshal grants to JSON: %w", marshalErr)
+		}
+		fmt.Fprintln(out, string(jsonBytes))
+		return nil
+	case "table":
+		return cli.Paginate(seq, cli.PagerConfig[types.Grant]{
+			Out:     out,
+			Columns: []string{"ID", "Action", "Recipients", "Created At"},
+			Row: func(grant types.Grant) []string {
+				return []string{
+					grant.ID,
+					grant.Action,
+					FormatConditions(grant.RecipientConditions),
+					grant.CreatedAt.Format("2006-01-02 15:04:05"),
+				}
+			},
+		})
+	default:
+		return fmt.Errorf("unsupported output format: %s", output)
+	}
+}
+
+var grantIDPattern = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+
+// The server rejects a non-UUID id with a raw GraphQL parse error, so catch it
+// here. listCmd names the command that lists ids.
+func ValidateGrantID(id, listCmd string) error {
+	if !grantIDPattern.MatchString(id) {
+		return fmt.Errorf("%q is not a grant id; run `%s` to find it", id, listCmd)
+	}
+	return nil
+}
+
+func NotFoundHint(err error, kind, id string) error {
+	if !errors.Is(err, gql.ErrNotFound) {
+		return err
+	}
+	return fmt.Errorf("%s %q does not exist", kind, id)
+}

--- a/internal/commands/grants/grants_test.go
+++ b/internal/commands/grants/grants_test.go
@@ -1,0 +1,200 @@
+package grants_test
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"iter"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/massdriver-cloud/mass/internal/commands/grants"
+	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/gql"
+	"github.com/massdriver-cloud/massdriver-sdk-go/massdriver/platform/types"
+)
+
+func TestRenderTable(t *testing.T) {
+	grant := types.Grant{
+		ID:                  "grant-1",
+		Action:              grants.ActionRepoPull,
+		RecipientConditions: types.PolicyConditions{"team": {"platform", "data"}},
+		CreatedAt:           time.Date(2026, 9, 10, 12, 30, 0, 0, time.UTC),
+	}
+
+	out, err := renderTo(t, func(out *os.File) error {
+		return grants.Render(grantSeq(grant), "table", out)
+	})
+	if err != nil {
+		t.Fatalf("Render returned error: %v", err)
+	}
+
+	for _, want := range []string{"grant-1", grants.ActionRepoPull, "team=platform|data", "2026-09-10 12:30:00"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("table output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRenderTableNamesTheWildcard(t *testing.T) {
+	out, err := renderTo(t, func(out *os.File) error {
+		return grants.Render(grantSeq(types.Grant{ID: "grant-1", Action: grants.ActionRepoPull}), "table", out)
+	})
+	if err != nil {
+		t.Fatalf("Render returned error: %v", err)
+	}
+	if !strings.Contains(out, "everyone") {
+		t.Errorf("table output missing %q:\n%s", "everyone", out)
+	}
+}
+
+func TestRenderJSONConditionsRoundTripThroughFile(t *testing.T) {
+	want := types.PolicyConditions{"team": {"platform", "data"}, "region": nil}
+
+	out, err := renderTo(t, func(out *os.File) error {
+		return grants.Render(grantSeq(types.Grant{ID: "grant-1", RecipientConditions: want}), "json", out)
+	})
+	if err != nil {
+		t.Fatalf("Render returned error: %v", err)
+	}
+
+	var rendered []struct {
+		RecipientConditions json.RawMessage `json:"recipientConditions"`
+	}
+	if unmarshalErr := json.Unmarshal([]byte(out), &rendered); unmarshalErr != nil {
+		t.Fatalf("rendered JSON did not parse: %v\n%s", unmarshalErr, out)
+	}
+	if len(rendered) != 1 {
+		t.Fatalf("rendered %d grants, want 1:\n%s", len(rendered), out)
+	}
+
+	file := filepath.Join(t.TempDir(), "conditions.json")
+	if writeErr := os.WriteFile(file, rendered[0].RecipientConditions, 0600); writeErr != nil {
+		t.Fatal(writeErr)
+	}
+
+	got, err := grants.ParseConditionsFile(file, "all-projects")
+	if err != nil {
+		t.Fatalf("ParseConditionsFile on rendered conditions returned error: %v", err)
+	}
+	if !conditionsEqual(got, want) {
+		t.Errorf("round trip = %v, want %v", got, want)
+	}
+}
+
+func TestRenderUnsupportedFormat(t *testing.T) {
+	err := grants.Render(grantSeq(), "yaml", os.Stdout)
+	if err == nil {
+		t.Fatal("Render succeeded, wanted error")
+	}
+	if !strings.Contains(err.Error(), "unsupported output format") {
+		t.Errorf("error = %q, want it to name the unsupported format", err)
+	}
+}
+
+func TestRenderPropagatesIterationError(t *testing.T) {
+	pageErr := errors.New("page fetch failed")
+
+	for _, format := range []string{"table", "json"} {
+		t.Run(format, func(t *testing.T) {
+			_, err := renderTo(t, func(out *os.File) error {
+				return grants.Render(failingSeq(pageErr), format, out)
+			})
+			if !errors.Is(err, pageErr) {
+				t.Errorf("Render error = %v, want %v", err, pageErr)
+			}
+		})
+	}
+}
+
+func TestValidateGrantID(t *testing.T) {
+	if err := grants.ValidateGrantID("4f2a9c18-1f0e-4a5c-9a3e-2b6d7c8e9f10", "mass repository grant list <name>"); err != nil {
+		t.Errorf("ValidateGrantID rejected a valid uuid: %v", err)
+	}
+
+	for _, id := range []string{"not-a-uuid", "123", "", "4f2a9c18-1f0e-4a5c-9a3e-2b6d7c8e9f1", "4f2a9c18_1f0e_4a5c_9a3e_2b6d7c8e9f10"} {
+		t.Run(id, func(t *testing.T) {
+			err := grants.ValidateGrantID(id, "mass repository grant list <name>")
+			if err == nil {
+				t.Fatalf("ValidateGrantID(%q) succeeded, wanted error", id)
+			}
+			if !strings.Contains(err.Error(), "mass repository grant list") {
+				t.Errorf("error = %q, want it to name the list command", err)
+			}
+		})
+	}
+}
+
+func TestNotFoundHint(t *testing.T) {
+	err := grants.NotFoundHint(gql.ErrNotFound, "repository", "aws-aurora-postgres")
+	if err == nil {
+		t.Fatal("NotFoundHint dropped the error")
+	}
+	for _, want := range []string{"repository", "aws-aurora-postgres", "does not exist"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error = %q, want it to contain %q", err, want)
+		}
+	}
+}
+
+func TestNotFoundHintUnwrapsWrappedErrors(t *testing.T) {
+	wrapped := fmt.Errorf("list oci repo grants: %w", gql.ErrNotFound)
+	err := grants.NotFoundHint(wrapped, "repository", "aws-aurora-postgres")
+	if !strings.Contains(err.Error(), "does not exist") {
+		t.Errorf("error = %q, want the not-found rewrite", err)
+	}
+}
+
+func TestNotFoundHintPassesOtherErrorsThrough(t *testing.T) {
+	original := errors.New("permission denied")
+	if err := grants.NotFoundHint(original, "repository", "aws-aurora-postgres"); !errors.Is(err, original) {
+		t.Errorf("NotFoundHint = %v, want %v", err, original)
+	}
+}
+
+func TestNotFoundHintNilStaysNil(t *testing.T) {
+	if err := grants.NotFoundHint(nil, "repository", "aws-aurora-postgres"); err != nil {
+		t.Errorf("NotFoundHint(nil) = %v, want nil", err)
+	}
+}
+
+// A plain file is not a TTY, so the table path streams instead of paging.
+func renderTo(t *testing.T, fn func(out *os.File) error) (string, error) {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "render.out")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	runErr := fn(file)
+
+	if closeErr := file.Close(); closeErr != nil {
+		t.Fatal(closeErr)
+	}
+	out, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+
+	return string(out), runErr
+}
+
+func grantSeq(items ...types.Grant) iter.Seq2[types.Grant, error] {
+	return func(yield func(types.Grant, error) bool) {
+		for _, item := range items {
+			if !yield(item, nil) {
+				return
+			}
+		}
+	}
+}
+
+func failingSeq(err error) iter.Seq2[types.Grant, error] {
+	return func(yield func(types.Grant, error) bool) {
+		yield(types.Grant{}, err)
+	}
+}


### PR DESCRIPTION
Adds grant management for OCI repositories and resources: `create`, `list`, and `delete` under each. Grants are immutable server-side, so there is no `update` — changing one means deleting it and creating a replacement.

## Commands

Repository grants match recipient **projects** and grant `repo:pull`. Resource grants match recipient **environments** and grant `resource:export`. Shared logic lives in `internal/commands/grants`, which serves both trees because `ocirepos.Grant` and `resources.Grant` are aliases of `types.Grant`.

These live under `repository` rather than `bundle` because nothing in the SDK or GraphQL schema scopes repo grants by artifact type — `createRepoGrant` takes any OCI repo id, and `grants` is a field on `OciRepo` itself. The server does currently reject resource-type repos ("resource-type repos are not grantable"), but that is a runtime restriction that may lift, not a reason to encode it in the command tree.

## Recipient conditions

Conditions come from exactly one of three mutually exclusive sources:

- `--condition key=value`, repeatable. Repeating a key unions its values into a closed set; `key=*` accepts any value as long as the attribute is set.
- `--conditions-file`, taking the JSON form that `grant list -o json` emits under `recipientConditions`.
- `--all-projects` / `--all-environments` for the organization-wide grant.

Requiring that last flag explicitly is deliberate: absence of conditions would otherwise make a typo silently produce the broadest possible grant. A conditions file holding `null` or `{}` is rejected for the same reason.

`--attributes`-style `StringToString` was not reusable here. pflag only comma-splits when an argument contains two or more `=`, so `-c team=platform,data` yields the single value `"platform,data"`, and repeating a key overwrites rather than unions — a closed set is not expressible, and both attempts to write one fail silently.

## Help text

Replaces every inline cobra `Example` field with a helpdoc, so examples live in `docs/helpdocs` alongside the rest of the CLI's prose. 32 of the 39 inline blocks duplicated a helpdoc that already had an `## Examples` section; every example line was diffed against its helpdoc before removal, and the two that were genuinely missing (`environment deploy --follow`, concrete `resource update` examples) were merged in. Four commands gained a helpdoc they never had: `bundle create`, `component update`, `instance destroy`, `resource delete`. No `Long:` string literals remain in `cmd/`.

## Lint

Disables revive's `exported` rule and staticcheck's `ST1020`/`ST1021`/`ST1022`. This module ships a binary, not a library, so a comment on an exported symbol is prose rather than generated API documentation — neither its presence nor its "Name ..." phrasing should be mandatory.

## Testing

Unit tests cover condition parsing, action validation, grant-id validation, and rendering (97% statement coverage on the new package). Verified end to end against a live organization: all four condition shapes round-trip faithfully through the server (closed set as an array, wildcard as `"*"`, org-wide as an omitted field), `grant list -o json` output feeds back into `--conditions-file` unchanged, and every error path behaves. All test data was cleaned up.

## Known follow-ups, not addressed here

- `grant create` on a missing source reports the server's message rather than the friendlier one `grant list` produces. The API returns `code: "unknown"` on every mutation validation message, so the SDK cannot classify it as `ErrNotFound`. Fix belongs in the API first, then the SDK; the CLI needs no change.
- `grant list -o json` prints `null` rather than `[]` for an empty result. This matches every other list command in the CLI, so fixing it here alone would be inconsistent.
- `resource grant delete` will delete a repository grant and vice versa — the server treats grants uniformly by id, as the SDK documents.
