### PR TITLE
Fix build after grants and config-profile merge

### DIFF
--- a/cmd/repository.go
+++ b/cmd/repository.go
@@ -447,7 +447,7 @@ func newRepositoryGrantCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
-			return runRepositoryGrantCreate(args[0], &createInput)
+			return runRepositoryGrantCreate(cmd, args[0], &createInput)
 		},
 	}
 	repositoryGrantCreateCmd.Flags().StringArrayVar(&createInput.conditions, "condition", nil, "Recipient project attribute condition; repeat a key to accept a set of values, or write key=* to accept any value")
@@ -480,7 +480,7 @@ func newRepositoryGrantCmd() *cobra.Command {
 	return repositoryGrantCmd
 }
 
-func runRepositoryGrantCreate(name string, input *repositoryGrantCreateInput) error {
+func runRepositoryGrantCreate(cmd *cobra.Command, name string, input *repositoryGrantCreateInput) error {
 	ctx := context.Background()
 
 	action, err := grants.ResolveRepoAction(input.action)
@@ -492,7 +492,7 @@ func runRepositoryGrantCreate(name string, input *repositoryGrantCreateInput) er
 		return err
 	}
 
-	mdClient, err := massdriver.NewClient()
+	mdClient, err := newMassdriverClient(cmd)
 	if err != nil {
 		return fmt.Errorf("error initializing massdriver client: %w", err)
 	}
@@ -520,7 +520,7 @@ func runRepositoryGrantList(cmd *cobra.Command, args []string) error {
 
 	cmd.SilenceUsage = true
 
-	mdClient, err := massdriver.NewClient()
+	mdClient, err := newMassdriverClient(cmd)
 	if err != nil {
 		return fmt.Errorf("error initializing massdriver client: %w", err)
 	}
@@ -539,7 +539,7 @@ func runRepositoryGrantDelete(cmd *cobra.Command, args []string) error {
 		return validateErr
 	}
 
-	mdClient, err := massdriver.NewClient()
+	mdClient, err := newMassdriverClient(cmd)
 	if err != nil {
 		return fmt.Errorf("error initializing massdriver client: %w", err)
 	}

--- a/cmd/resource.go
+++ b/cmd/resource.go
@@ -450,7 +450,7 @@ func newResourceGrantCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
-			return runResourceGrantCreate(args[0], &createInput)
+			return runResourceGrantCreate(cmd, args[0], &createInput)
 		},
 	}
 	resourceGrantCreateCmd.Flags().StringArrayVar(&createInput.conditions, "condition", nil, "Recipient environment attribute condition; repeat a key to accept a set of values, or write key=* to accept any value")
@@ -483,7 +483,7 @@ func newResourceGrantCmd() *cobra.Command {
 	return resourceGrantCmd
 }
 
-func runResourceGrantCreate(resourceID string, input *resourceGrantCreateInput) error {
+func runResourceGrantCreate(cmd *cobra.Command, resourceID string, input *resourceGrantCreateInput) error {
 	ctx := context.Background()
 
 	action, err := grants.ResolveResourceAction(input.action)
@@ -495,7 +495,7 @@ func runResourceGrantCreate(resourceID string, input *resourceGrantCreateInput) 
 		return err
 	}
 
-	mdClient, err := massdriver.NewClient()
+	mdClient, err := newMassdriverClient(cmd)
 	if err != nil {
 		return fmt.Errorf("error initializing massdriver client: %w", err)
 	}
@@ -523,7 +523,7 @@ func runResourceGrantList(cmd *cobra.Command, args []string) error {
 
 	cmd.SilenceUsage = true
 
-	mdClient, err := massdriver.NewClient()
+	mdClient, err := newMassdriverClient(cmd)
 	if err != nil {
 		return fmt.Errorf("error initializing massdriver client: %w", err)
 	}
@@ -542,7 +542,7 @@ func runResourceGrantDelete(cmd *cobra.Command, args []string) error {
 		return validateErr
 	}
 
-	mdClient, err := massdriver.NewClient()
+	mdClient, err := newMassdriverClient(cmd)
 	if err != nil {
 		return fmt.Errorf("error initializing massdriver client: %w", err)
 	}

--- a/docs/generated/mass_repository_grant.md
+++ b/docs/generated/mass_repository_grant.md
@@ -38,6 +38,12 @@ mass repository grant delete <grant-id>
   -h, --help   help for grant
 ```
 
+### Options inherited from parent commands
+
+```
+      --profile string   Configuration profile to use (overrides MASSDRIVER_PROFILE and the active profile)
+```
+
 ### SEE ALSO
 
 * [mass repository](/cli/commands/mass_repository)	 - Manage OCI repositories (bundles and resource types)

--- a/docs/generated/mass_repository_grant_create.md
+++ b/docs/generated/mass_repository_grant_create.md
@@ -83,6 +83,12 @@ mass repository grant create <name> [flags]
   -h, --help                     help for create
 ```
 
+### Options inherited from parent commands
+
+```
+      --profile string   Configuration profile to use (overrides MASSDRIVER_PROFILE and the active profile)
+```
+
 ### SEE ALSO
 
 * [mass repository grant](/cli/commands/mass_repository_grant)	 - Manage sharing grants on an OCI repository

--- a/docs/generated/mass_repository_grant_delete.md
+++ b/docs/generated/mass_repository_grant_delete.md
@@ -44,6 +44,12 @@ mass repository grant delete <grant-id> [flags]
   -h, --help   help for delete
 ```
 
+### Options inherited from parent commands
+
+```
+      --profile string   Configuration profile to use (overrides MASSDRIVER_PROFILE and the active profile)
+```
+
 ### SEE ALSO
 
 * [mass repository grant](/cli/commands/mass_repository_grant)	 - Manage sharing grants on an OCI repository

--- a/docs/generated/mass_repository_grant_list.md
+++ b/docs/generated/mass_repository_grant_list.md
@@ -53,6 +53,12 @@ mass repository grant list <name> [flags]
   -o, --output string   Output format (table, json) (default "table")
 ```
 
+### Options inherited from parent commands
+
+```
+      --profile string   Configuration profile to use (overrides MASSDRIVER_PROFILE and the active profile)
+```
+
 ### SEE ALSO
 
 * [mass repository grant](/cli/commands/mass_repository_grant)	 - Manage sharing grants on an OCI repository

--- a/docs/generated/mass_resource_grant.md
+++ b/docs/generated/mass_resource_grant.md
@@ -38,6 +38,12 @@ mass resource grant delete <grant-id>
   -h, --help   help for grant
 ```
 
+### Options inherited from parent commands
+
+```
+      --profile string   Configuration profile to use (overrides MASSDRIVER_PROFILE and the active profile)
+```
+
 ### SEE ALSO
 
 * [mass resource](/cli/commands/mass_resource)	 - Manage resources

--- a/docs/generated/mass_resource_grant_create.md
+++ b/docs/generated/mass_resource_grant_create.md
@@ -84,6 +84,12 @@ mass resource grant create <resource-id> [flags]
   -h, --help                     help for create
 ```
 
+### Options inherited from parent commands
+
+```
+      --profile string   Configuration profile to use (overrides MASSDRIVER_PROFILE and the active profile)
+```
+
 ### SEE ALSO
 
 * [mass resource grant](/cli/commands/mass_resource_grant)	 - Manage sharing grants on a resource

--- a/docs/generated/mass_resource_grant_delete.md
+++ b/docs/generated/mass_resource_grant_delete.md
@@ -44,6 +44,12 @@ mass resource grant delete <grant-id> [flags]
   -h, --help   help for delete
 ```
 
+### Options inherited from parent commands
+
+```
+      --profile string   Configuration profile to use (overrides MASSDRIVER_PROFILE and the active profile)
+```
+
 ### SEE ALSO
 
 * [mass resource grant](/cli/commands/mass_resource_grant)	 - Manage sharing grants on a resource

--- a/docs/generated/mass_resource_grant_list.md
+++ b/docs/generated/mass_resource_grant_list.md
@@ -53,6 +53,12 @@ mass resource grant list <resource-id> [flags]
   -o, --output string   Output format (table, json) (default "table")
 ```
 
+### Options inherited from parent commands
+
+```
+      --profile string   Configuration profile to use (overrides MASSDRIVER_PROFILE and the active profile)
+```
+
 ### SEE ALSO
 
 * [mass resource grant](/cli/commands/mass_resource_grant)	 - Manage sharing grants on a resource


### PR DESCRIPTION
#252 (config profiles) and #253 (repo/resource grants) merged cleanly as text but not as code. #252 introduced `newMassdriverClient(cmd)` in `cmd/client.go`, which resolves the `--profile` flag, and converted every call site in the files it touched. The grant commands landed afterward still calling `massdriver.NewClient()` directly.

## Why only one file failed the build

`cmd/resource.go` no longer imports `massdriver` — #252 removed it once its own call sites were converted — so the three grant calls failed with `undefined: massdriver`.

`cmd/repository.go` kept the import, because `createOciRepoCommon` uses `*massdriver.Client` as a parameter type. It compiled, and its three grant commands silently ignored `--profile`. That one would have shipped unnoticed.

## Changes

- All six grant call sites now go through `newMassdriverClient(cmd)`.
- `runRepositoryGrantCreate` and `runResourceGrantCreate` take `cmd *cobra.Command` as their first parameter, matching how #252 threaded it into `runRepositoryList`. The list and delete runners already had it.
- Regenerated the eight `docs/generated/mass_*_grant*.md` pages. They were produced before `--profile` existed and were missing its "Options inherited from parent commands" section.

## Verification

`make check` passes. Confirmed the flag is wired rather than merely compiling — `mass repository grant create <name> --all-projects --profile no-such-profile` now fails with `profile not found`, where before it accepted and ignored the flag. Exercised create, list, and delete against a live organization on a throwaway repository, then removed it.

## Not included

`cmd/config.go` carries seven inline cobra `Example` fields. #252 predates the sweep in #253 that moved all other examples into `docs/helpdocs`, so the convention is inconsistent again. Converting them means authoring seven new helpdocs, which belongs in its own PR.
